### PR TITLE
:recycle: [REFACTOR] Refresh Token 적용에 따른 내부 데이터 처리 및 회원가입 여부 분기처리 로직 변경

### DIFF
--- a/app/src/main/java/com/zipdabang/zipdabang_android/common/Constants.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/common/Constants.kt
@@ -4,6 +4,8 @@ object Constants {
     const val BASE_URL = "https://api.zipdabang.shop/"
     const val PLATFORM_KAKAO = "kakao"
     const val PLATFORM_GOOGLE = "google"
+    const val PLATFORM_TEMP = "temp"
+    const val PLATFORM_NONE = "none"
 
     //----------------------------------------------------------------------------------------------
     const val AUTH_NAV_GRAPH = "AuthNavGraph"

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoData.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoData.kt
@@ -8,8 +8,8 @@ import kotlinx.serialization.Serializable
 data class Token(
     var accessToken: String?,
     var refreshToken: String?,
-    var platformStatus: CurrentPlatform,
     var platformToken: String?,
+    var platformStatus: CurrentPlatform,
     var fcmToken: String?
 )
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoDataViewModel.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoDataViewModel.kt
@@ -22,10 +22,9 @@ class ProtoDataViewModel @Inject constructor(
     // 사용할 곳(UI)에서 collectAsState 적용
     val tokens = protoRepository.tokens
 
-
-    fun updatePlatformToken(platform: CurrentPlatform, platformToken: String) {
+    fun updatePlatform(platform: CurrentPlatform) {
         viewModelScope.launch {
-            protoRepository.updatePlatformToken(platform, platformToken)
+            protoRepository.updatePlatform(platform)
             Log.d(TAG, "${protoRepository.tokens}")
         }
     }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoRepository.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoRepository.kt
@@ -6,7 +6,7 @@ interface ProtoRepository {
 
     val tokens: Flow<Token>
 
-    suspend fun updatePlatformToken(platform: CurrentPlatform, platformToken: String)
+    suspend fun updatePlatform(platform: CurrentPlatform)
 
     suspend fun updateAccessToken(accessToken: String)
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoRepositoryImpl.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoRepositoryImpl.kt
@@ -13,12 +13,11 @@ class ProtoRepositoryImpl @Inject constructor(
 
     override val tokens: Flow<Token> = protoDataStore.data
 
-    override suspend fun updatePlatformToken(platform: CurrentPlatform, platformToken: String) {
+    override suspend fun updatePlatform(platform: CurrentPlatform) {
         protoDataStore.updateData { token ->
             // preferences.toBuilder().setShowCompleted(completed).build()
             token.copy(
-                platformStatus = platform,
-                platformToken = platformToken
+                platformStatus = platform
             )
         }
     }
@@ -53,7 +52,6 @@ class ProtoRepositoryImpl @Inject constructor(
                 accessToken = null,
                 refreshToken = null,
                 platformStatus = CurrentPlatform.NONE,
-                platformToken = null,
                 fcmToken = null
             )
         }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoSerializer.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/ProtoSerializer.kt
@@ -12,8 +12,8 @@ object ProtoSerializer: Serializer<Token> {
         get() = Token(
             accessToken = null,
             refreshToken = null,
-            platformStatus = CurrentPlatform.NONE,
             platformToken = null,
+            platformStatus = CurrentPlatform.NONE,
             fcmToken = null
         )
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/test/DataStoreTestScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/test/DataStoreTestScreen.kt
@@ -21,9 +21,9 @@ fun DataStoreTestScreen(
     val tokens = viewModel.tokens.collectAsState(initial = Token(
         null,
         null,
+        null,
         CurrentPlatform.NONE,
         null,
-        null
     )
     )
 
@@ -52,7 +52,7 @@ fun DataStoreTestScreen(
         }
 
         Button(onClick = {
-            viewModel.updatePlatformToken(CurrentPlatform.KAKAO, "new_kakao_token")
+            viewModel.updatePlatform(CurrentPlatform.KAKAO)
             Log.d(TAG, "${tokens.value}")
         }) {
             Text(text = "PLATFORM TOKEN")

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/AuthNavGraph.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/AuthNavGraph.kt
@@ -21,11 +21,29 @@ fun NavGraphBuilder.authNavGraph(navController: NavHostController) {
             val authSharedViewModel = navBackStackEntry
                 .authSharedViewModel<AuthSharedViewModel>(navController = navController)
             LoginScreen(
-                onSuccess = {
+                onSuccess = { email, profile ->
+                    authSharedViewModel.apply {
+                        updateEmail(email)
+                        updateProfile(profile)
+                    }
+                    navController.navigate(MAIN_ROUTE) {
+                        popUpTo(AuthScreen.SignIn.route) {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                },
+
+                onRegister = { email, profile ->
+                    authSharedViewModel.apply {
+                        updateEmail(email)
+                        updateProfile(profile)
+                    }
                     navController.navigate(AuthScreen.Terms.route) {
                         launchSingleTop = true
                     }
                 },
+
                 onLoginLater = {
                     navController.navigate(MAIN_ROUTE){
                         launchSingleTop = true

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/AuthSharedViewModel.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/AuthSharedViewModel.kt
@@ -19,10 +19,17 @@ class AuthSharedViewModel @Inject constructor(savedStateHandle: SavedStateHandle
     private val _email = MutableStateFlow("")
     val email = _email.asStateFlow()
 
+    private val _profile = MutableStateFlow("")
+    val profile = _profile.asStateFlow()
+
     // 다른 회원정보들 dto로 만들어서 담기?
 
     fun updateEmail(email: String) {
         _email.value = email
+    }
+
+    fun updateProfile(profile: String) {
+        _profile.value = profile
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/data/AuthBody.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/data/AuthBody.kt
@@ -3,6 +3,5 @@ package com.zipdabang.zipdabang_android.module.login.data
 import com.google.gson.annotations.SerializedName
 
 data class AuthBody(
-    @SerializedName("email") val email: String,
-    @SerializedName("profileUrl") val profileUrl: String
+    @SerializedName("email") val email: String
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/data/AuthDto.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/data/AuthDto.kt
@@ -4,5 +4,5 @@ data class AuthDto(
     val code: Int,
     val isSuccess: Boolean,
     val message: String,
-    val result: AuthTokenDto
+    val result: AuthTokenDto?
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/data/AuthTokenDto.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/data/AuthTokenDto.kt
@@ -1,5 +1,6 @@
 package com.zipdabang.zipdabang_android.module.login.data
 
 data class AuthTokenDto(
-    val accessToken: String
+    val accessToken: String,
+    val refreshToken: String
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/domain/Auth.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/domain/Auth.kt
@@ -2,5 +2,10 @@ package com.zipdabang.zipdabang_android.module.login.domain
 
 data class Auth(
     val code: Int,
-    val token: String
+    val zipdabangToken: ZipdabangToken?
+)
+
+data class ZipdabangToken(
+    val accessToken: String?,
+    val refreshToken: String?
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/mapper/AuthMapper.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/mapper/AuthMapper.kt
@@ -2,10 +2,16 @@ package com.zipdabang.zipdabang_android.module.login.mapper
 
 import com.zipdabang.zipdabang_android.module.login.data.AuthDto
 import com.zipdabang.zipdabang_android.module.login.domain.Auth
+import com.zipdabang.zipdabang_android.module.login.domain.ZipdabangToken
 
 fun AuthDto.toAuth(): Auth {
     return Auth(
         code = code,
-        token = result.accessToken
+        zipdabangToken = result?.let {
+            ZipdabangToken(
+                accessToken = it.accessToken,
+                refreshToken = it.refreshToken
+            )
+        } ?: null
     )
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/ui/AuthState.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/ui/AuthState.kt
@@ -1,7 +1,9 @@
 package com.zipdabang.zipdabang_android.module.login.ui
 
+import com.zipdabang.zipdabang_android.module.login.domain.ZipdabangToken
+
 data class AuthState(
     val isLoading: Boolean = false,
-    val token: String? = null,
+    val zipdabangToken: ZipdabangToken? = null,
     val error: String? = null
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/ui/LoginScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/ui/LoginScreen.kt
@@ -33,6 +33,7 @@ import androidx.navigation.NavHostController
 import com.google.android.gms.auth.api.identity.Identity
 import com.zipdabang.zipdabang_android.R
 import com.zipdabang.zipdabang_android.common.Constants
+import com.zipdabang.zipdabang_android.core.data_store.ProtoDataViewModel
 import com.zipdabang.zipdabang_android.core.navigation.AuthSharedViewModel
 import com.zipdabang.zipdabang_android.module.login.platform_client.GoogleAuthClient
 import com.zipdabang.zipdabang_android.module.login.platform_client.KakaoAuthClient
@@ -49,7 +50,9 @@ import kotlinx.coroutines.withContext
 @Composable
 fun LoginScreen(
     viewModel: LoginViewModel = hiltViewModel(),
-    onSuccess: () -> Unit,
+    tokenStoreViewModel: ProtoDataViewModel = hiltViewModel(),
+    onSuccess: (String, String) -> Unit,
+    onRegister: (String, String) -> Unit,
     onLoginLater: ()-> Unit
 ) {
     val TAG = "LoginScreen"
@@ -77,7 +80,7 @@ fun LoginScreen(
                     val signInResult = googleAuthClient.signInWithIntent(
                         intent = result.data ?: return@launch
                     )
-                    Log.d(TAG, "Sign In Result : ${signInResult}")
+                    Log.d(TAG, "Sign In Result : $signInResult")
 
                     signInResult?.data?.let {
                         if (it.email != null && it.profile != null) {
@@ -90,16 +93,14 @@ fun LoginScreen(
                             val profile = googleUserInfo.profile
                             val email = googleUserInfo.email
                             viewModel.getAuthResult(
-                                body = AuthBody(email!!, profile!!),
+                                body = AuthBody(email!!),
                                 platform = Constants.PLATFORM_GOOGLE,
                                 email = email,
-                                onSuccess = onSuccess
+                                profile = profile!!,
+                                tokenStoreViewModel = tokenStoreViewModel,
+                                onSuccess = onSuccess,
+                                onRegister = onRegister
                             )
-                            /*if (!state.isLoading && state.token != "" && state.error == "") {
-                                onSuccess(email)
-                            }*/
-
-//                            onSuccess(email)
                         }
                     }
                 }
@@ -147,8 +148,6 @@ fun LoginScreen(
                                 ).build()
                             )
 
-
-
                             // back-end database access
 
                             // main ui
@@ -174,12 +173,14 @@ fun LoginScreen(
                                 val profile = result.data.profile
                                 Log.d(TAG, "email: $email, profile: $profile")
                                 viewModel.getAuthResult(
-                                    body = AuthBody(email, profile),
+                                    body = AuthBody(email),
                                     platform = Constants.PLATFORM_KAKAO,
+                                    tokenStoreViewModel = tokenStoreViewModel,
                                     email = email,
-                                    onSuccess = onSuccess
+                                    profile = profile,
+                                    onSuccess = onSuccess,
+                                    onRegister = onRegister
                                 )
-
                             } else {
 
                             }
@@ -214,9 +215,10 @@ fun LoginScreen(
     }
 }
 
+/*
 fun onAuthCompleted(state: AuthState, email: String, onSuccess: (String) -> Unit) {
     Log.d("LoginScreen", "$state, $email")
     if (!state.isLoading && state.token != null && state.error == null) {
         onSuccess(email)
     }
-}
+}*/

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/ui/LoginViewModel.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/ui/LoginViewModel.kt
@@ -6,7 +6,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zipdabang.zipdabang_android.common.Constants
 import com.zipdabang.zipdabang_android.common.Resource
+import com.zipdabang.zipdabang_android.core.data_store.CurrentPlatform
+import com.zipdabang.zipdabang_android.core.data_store.ProtoDataViewModel
 import com.zipdabang.zipdabang_android.module.login.data.AuthBody
 import com.zipdabang.zipdabang_android.module.login.use_case.GetAuthResultUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -31,21 +34,60 @@ class LoginViewModel @Inject constructor (
         body: AuthBody,
         platform: String,
         email: String,
-        onSuccess: () -> Unit
+        profile: String,
+        tokenStoreViewModel: ProtoDataViewModel,
+        onSuccess: (String, String) -> Unit,
+        onRegister: (String, String) -> Unit
     ) {
         getAuthResultUseCase(body, platform).onEach { result ->
             // 별 일이 없으면, 첫 번째로는 Resource.Loading이 발행되고, 두 번째로는 Resource.success가 발행.
             // 발행 중 문제가 생기면 Resource.Error 발행
             when (result) {
                 is Resource.Success -> {
-                    // 두 번째로 방출되는 것 처리
                     _state.value = AuthState(
                         isLoading = false,
-                        token = result.data?.token,
+                        zipdabangToken = result.data?.zipdabangToken,
                         error = null
                     )
-                    Log.d(TAG, "success ${state}")
-                    onSuccess()
+                    Log.d(TAG, "success $state")
+
+                    when (platform) {
+                        Constants.PLATFORM_GOOGLE -> {
+                            tokenStoreViewModel.updatePlatform(CurrentPlatform.GOOGLE)
+                        }
+                        Constants.PLATFORM_KAKAO -> {
+                            tokenStoreViewModel.updatePlatform(CurrentPlatform.KAKAO)
+                        }
+                        Constants.PLATFORM_TEMP -> {
+                            tokenStoreViewModel.updatePlatform(CurrentPlatform.TEMP)
+                        }
+                        else -> {
+                            tokenStoreViewModel.updatePlatform(CurrentPlatform.NONE)
+                        }
+                    }
+
+                    if (state.value.zipdabangToken != null) {
+                        if (state.value.zipdabangToken!!.accessToken != null
+                            && state.value.zipdabangToken!!.refreshToken != null) {
+                            state.value.zipdabangToken!!.accessToken?.let {
+                                tokenStoreViewModel.updateAccessToken(
+                                    it
+                                )
+                            }
+                            state.value.zipdabangToken!!.refreshToken?.let {
+                                tokenStoreViewModel.updateRefreshToken(
+                                    it
+                                )
+                            }
+                            onSuccess(email, profile)
+                        } else {
+                            Log.d(TAG, "onRegister - no acc, ref token")
+                            onRegister(email, profile)
+                        }
+                    } else {
+                        Log.d(TAG, "onRegister - no zipdabang token data")
+                        onRegister(email, profile)
+                    }
                 }
                 is Resource.Error -> {
                     // 오류 발생 시 처라

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/use_case/GetAuthResultUseCase.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/use_case/GetAuthResultUseCase.kt
@@ -34,28 +34,3 @@ class GetAuthResultUseCase @Inject constructor(
 
     }
 }
-
-/*
-
-class GetGoogleAuthResultUseCase @Inject constructor(
-    private val repository: AuthRepository
-) {
-    operator fun invoke(body: AuthBody): Flow<Resource<Auth>> = flow {
-        try {
-            emit(Resource.Loading())
-            val authResult = repository.getAuthResult(body, "google").toAuth()
-            emit(
-                Resource.Success(
-                    data = authResult,
-                    code = authResult.code,
-                    message = ResponseCode.getMessageByCode(authResult.code)
-                )
-            )
-        } catch (e: HttpException) {
-            emit(Resource.Error(e.localizedMessage ?: "unexpected error"))
-        } catch (e: IOException) {
-            emit(Resource.Error("couldn't reach server, check internet connection"))
-        }
-
-    }
-}*/


### PR DESCRIPTION
### 🚩 관련 이슈
refresh token 적용하여 내부 데이터 처리 로직 및 분기처리 관련 Refactor 진행했습니다.
서버에 넘겨주는 데이터 중 profileUrl 제외

### 📋 PR Checklist
- [ ] 소셜로그인과 그 결과에 따른 서버와의 통신이 적절히 이뤄지는가
- [ ] 화면 이동이 적절히 이뤄지는가
- [ ] Proto Datastore에 토큰이 적절히 저장되어 있는가

### 📌 유의사항
유저가 처음으로 로그인을 하면 반환되는 토큰 없이 회원가입 로직으로 넘어가야 하며
회원가입이 이미 이뤄진 상태라면 메인화면으로 넘어가야 합니다.

### ✅ 테스트 결과
코드는 정상적으로 동작해야 합니다. 