### PR TITLE
:recycle: [REFACTOR] Passing FCM Token and Device Number to Server

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
 
     <application
         android:name=".core.ZipdabangApplication"

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoData.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoData.kt
@@ -10,7 +10,9 @@ data class Token(
     var refreshToken: String?,
     var platformToken: String?,
     var platformStatus: CurrentPlatform,
-    var fcmToken: String?
+    var fcmToken: String?,
+    // 새로운 필드 추가 시, 기본값을 설정해 주어야 런타임 에러를 피할 수 있음
+    var deviceNumber: String? = null
 )
 
 // 선택의 폭을 제한

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoDataViewModel.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoDataViewModel.kt
@@ -51,6 +51,12 @@ class ProtoDataViewModel @Inject constructor(
         }
     }
 
+    fun updateDeviceNumber(deviceNumber: String) {
+        viewModelScope.launch {
+            protoRepository.updateDeviceNumber(deviceNumber)
+        }
+    }
+
     fun resetToken() {
         viewModelScope.launch {
             protoRepository.resetToken()

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoRepository.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoRepository.kt
@@ -16,5 +16,7 @@ interface ProtoRepository {
 
     suspend fun updateFcmToken(fcmToken: String)
 
+    suspend fun updateDeviceNumber(deviceNumber: String)
+
     suspend fun resetToken()
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoRepositoryImpl.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoRepositoryImpl.kt
@@ -54,6 +54,14 @@ class ProtoRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateDeviceNumber(deviceNumber: String) {
+        protoDataStore.updateData { token ->
+            token.copy(
+                deviceNumber = deviceNumber
+            )
+        }
+    }
+
     override suspend fun resetToken() {
         protoDataStore.updateData { token ->
             token.copy(

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoSerializer.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/proto/ProtoSerializer.kt
@@ -18,7 +18,8 @@ object ProtoSerializer: Serializer<Token> {
             refreshToken = null,
             platformToken = null,
             platformStatus = CurrentPlatform.NONE,
-            fcmToken = null
+            fcmToken = null,
+            deviceNumber = null
         )
 
     override suspend fun readFrom(input: InputStream): Token {

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/test/DataStoreTestScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/data_store/test/DataStoreTestScreen.kt
@@ -53,6 +53,7 @@ fun DataStoreTestScreen(
         null,
         CurrentPlatform.NONE,
         null,
+        null
     )
     )
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/data/AuthBody.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/data/AuthBody.kt
@@ -3,5 +3,7 @@ package com.zipdabang.zipdabang_android.module.login.data
 import com.google.gson.annotations.SerializedName
 
 data class AuthBody(
-    @SerializedName("email") val email: String
+    @SerializedName("email") val email: String,
+    @SerializedName("fcmToken") val fcmToken: String,
+    @SerializedName("serialNumber") val serialNumber: String
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/main/MainActivity.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/main/MainActivity.kt
@@ -5,21 +5,39 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.Manifest
+import android.content.Context
+import android.provider.Settings
+import android.telephony.TelephonyManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.core.content.ContextCompat
 import androidx.datastore.core.DataStore
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.messaging.ktx.messaging
+import com.zipdabang.zipdabang_android.common.Constants.TOKEN_NULL
+import com.zipdabang.zipdabang_android.core.data_store.proto.CurrentPlatform
 import com.zipdabang.zipdabang_android.core.data_store.proto.ProtoDataViewModel
 import com.zipdabang.zipdabang_android.core.data_store.proto.Token
+import com.zipdabang.zipdabang_android.core.data_store.proto.tokenDataStore
 import com.zipdabang.zipdabang_android.core.navigation.RootNavGraph
 import com.zipdabang.zipdabang_android.ui.theme.ZipdabangandroidTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Inject
+import kotlin.reflect.typeOf
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -43,8 +61,73 @@ class MainActivity : ComponentActivity() {
             }
 
             val tokenDataViewModel = hiltViewModel<ProtoDataViewModel>()
-            registerDerivedToken(tokenDataViewModel)
+
+            LaunchedEffect(key1 = true) {
+                registerDeviceNumber()
+                registerDerivedToken()
+            }
         }
+    }
+
+
+    private suspend fun registerDeviceNumber() {
+        CoroutineScope(Dispatchers.IO).launch {
+            // snapshot of the token
+            val deviceNumber = tokenDataStore.data.first().deviceNumber
+            Log.d(TAG, "deviceNumber is $deviceNumber")
+
+            Log.d(TAG, "deviceNumber test starts")
+
+            if (deviceNumber == null) {
+                Log.d(TAG, "deviceNumber is null, get uuid")
+                val uuid = UUID.randomUUID().toString()
+                Log.d(TAG, "datastore deviceNumber is null, this uuid is to be into the datastore : $uuid")
+                tokenDataStore.updateData { tokens ->
+                    tokens.copy(
+                        deviceNumber = uuid
+                    )
+                }
+            }
+        }
+
+    }
+
+    private suspend fun registerDerivedToken() {
+        // [START log_reg_token]
+        Firebase.messaging.token.addOnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                Log.w(TAG, "Fetching FCM registration token failed", task.exception)
+                return@addOnCompleteListener
+            }
+
+            // Get new FCM registration token
+            val token = task.result
+
+            // 저장소에 업데이트
+            // viewModel.updateFcmToken(token)
+
+            // Log and toast
+            val msg = "FCM Registration token: $token"
+            Log.d(TAG, msg)
+
+            CoroutineScope(Dispatchers.IO).launch {
+
+                var fcmToken = "null"
+
+                Log.d(TAG, "update started")
+
+                fcmToken = tokenDataStore.updateData { tokens ->
+                    Log.d(TAG, "update in progress")
+                    tokens.copy(
+                        fcmToken = token
+                    )
+                }.fcmToken ?: TOKEN_NULL
+
+                Log.d(TAG, "fcm token update completed,\nfcm token is $fcmToken")
+            }
+            // TODO 토큰 서버에 전송 api
+        }
+        // [END log_reg_token]
     }
 
     private fun askNotificationPermission() {
@@ -76,30 +159,5 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun registerDerivedToken(viewModel: ProtoDataViewModel) {
-        // [START log_reg_token]
-        Firebase.messaging.token.addOnCompleteListener { task ->
-            if (!task.isSuccessful) {
-                Log.w(TAG, "Fetching FCM registration token failed", task.exception)
-                return@addOnCompleteListener
-            }
 
-            // Get new FCM registration token
-            val token = task.result
-
-            // 저장소에 업데이트
-            viewModel.updateFcmToken(token)
-
-            // 서버로 전송
-
-            // Log and toast
-            val msg = "FCM Registration token: $token"
-            Log.d(TAG, msg)
-
-
-
-            // TODO 토큰 서버에 전송 api
-        }
-        // [END log_reg_token]
-    }
 }


### PR DESCRIPTION
### 🚩 관련 이슈
온보딩에서 소셜로그인 진행 시 FCM Token과 디바이스 번호를 서버에 전달
디바이스 번호는 UUID를 활용

### 📋 PR Checklist
- [ ] data store에 이미 device number가 들어가 있다면 갱신이 되지 않는지 체크(삭제 시까지 불변)

### 📌 유의사항
없음

### ✅ 테스트 결과
정상적으로 동작함. 약관동의로 잘 넘어감