### PR TITLE
:alien: [FIX] signup post api Complete, but logout is not complete

### DIFF
--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/AuthNavGraph.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/AuthNavGraph.kt
@@ -96,12 +96,13 @@ fun NavGraphBuilder.authNavGraph(navController: NavHostController) {
                     navController.popBackStack(AuthScreen.Terms.route, inclusive = false)
                 },
                 onClickNext = {
-                    navController.navigate(AuthScreen.RegisterUserAddress.route)
+                    navController.navigate(AuthScreen.RegisterNickname.route)
                 }
             )
         }
 
-        composable(route =AuthScreen.RegisterUserAddress.route) {navBackStackEntry ->
+        // 상세 주소
+        /*composable(route =AuthScreen.RegisterUserAddress.route) {navBackStackEntry ->
             val authSharedViewModel = navBackStackEntry.authSharedViewModel<AuthSharedViewModel>(navController = navController)
             RegisterUserAddressScreen(
                 navController = navController,
@@ -113,7 +114,7 @@ fun NavGraphBuilder.authNavGraph(navController: NavHostController) {
                     navController.navigate(AuthScreen.RegisterNickname.route)
                 }
             )
-        }
+        }*/
 
         composable(route =AuthScreen.RegisterNickname.route) {navBackStackEntry ->
             val authSharedViewModel = navBackStackEntry.authSharedViewModel<AuthSharedViewModel>(navController = navController)
@@ -121,7 +122,7 @@ fun NavGraphBuilder.authNavGraph(navController: NavHostController) {
                 navController = navController,
                 authSharedViewModel = authSharedViewModel,
                 onClickBack = {
-                    navController.popBackStack(AuthScreen.RegisterUserAddress.route, inclusive = false)
+                    navController.popBackStack(AuthScreen.RegisterUserInfo.route, inclusive = false)
                 },
                 onClickNext = {
                     navController.navigate(AuthScreen.RegisterPreferences.route)
@@ -141,9 +142,7 @@ fun NavGraphBuilder.authNavGraph(navController: NavHostController) {
                 },
                 onClickNext = {
                     Log.e("signup-tokens", "넘어가져2")
-                    navController.navigate(MAIN_ROUTE){
-                        launchSingleTop = true
-                    }
+                    navController.popBackStack(MAIN_ROUTE, inclusive = false)
                 }
             )
         }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/sign_up/data/remote/InfoRequest.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/sign_up/data/remote/InfoRequest.kt
@@ -1,10 +1,10 @@
 package com.zipdabang.zipdabang_android.module.sign_up.data.remote
 
 data class InfoRequest(
-    val address: String,
+    //val address: String,
     val agreeTermsIdList: List<Int>,
     val birth: String,
-    val detailAddress: String,
+    //val detailAddress: String,
     val email: String,
     val gender: String,
     val name: String,
@@ -12,5 +12,5 @@ data class InfoRequest(
     val phoneNum: String,
     val preferBeverages: List<Int>,
     val profileUrl: String,
-    val zipCode: String
+    //val zipCode: String
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/sign_up/ui/RegisterPreferencesScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/sign_up/ui/RegisterPreferencesScreen.kt
@@ -206,7 +206,7 @@ fun RegisterPreferencesScreen(
                     onClick={
                         CoroutineScope(Dispatchers.Main).launch {
                             try{
-                                //Log.e("signup-tokens","api 실행 전")
+                                Log.e("signup-tokens","api 실행 전")
                                 authSharedViewModel.postInfo(tokenStoreViewModel)
                                 Log.e("signup-tokens","넘어가져1")
                                 onClickNext()

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/sign_up/ui/viewmodel/AuthSharedViewModel.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/sign_up/ui/viewmodel/AuthSharedViewModel.kt
@@ -77,9 +77,13 @@ class AuthSharedViewModel @Inject constructor(
     suspend fun updateSocial(){
         social = dataStore.data.first().platformStatus.toString()
     }
+    suspend fun printTokens(){
+        Log.e("signup-tokens", "토큰 출력 : accessToken ${dataStore.data.first().accessToken}")
+        Log.e("signup-tokens", "토큰 출력 : refreshToken ${dataStore.data.first().refreshToken}")
+    }
 
 
-    // info 글자수 제한하기, 생년월일 더 제한, response enum class로 옮기기, textfield 옮겨갈때마다 focusing
+    // response enum class로 옮기기
 
 
     /*TermsScreen*/
@@ -668,9 +672,9 @@ class AuthSharedViewModel @Inject constructor(
                     birth = stateUserInfoForm.birthday,
                     phoneNum = "01012345678", //stateUserInfoForm.phoneNumber,
                     gender = if (stateUserInfoForm.gender == "남") "1" else "2",
-                    zipCode = stateUserAddressForm.zipCode,
-                    address = stateUserAddressForm.address,
-                    detailAddress = stateUserAddressForm.detailAddress,
+                    //zipCode = stateUserAddressForm.zipCode,
+                    //address = stateUserAddressForm.address,
+                    //detailAddress = stateUserAddressForm.detailAddress,
                     nickname = stateNicknameForm.nickname,
                     preferBeverages = stateBeverageForm.beverageCheckList.mapIndexedNotNull { index, isSelected ->
                         if (isSelected) index+1 else null
@@ -681,19 +685,19 @@ class AuthSharedViewModel @Inject constructor(
             result.collect{ result ->
                 when(result){
                     is Resource.Success ->{
+                        Log.e("signup-tokens", "api 성공 response : ${result.data?.result}")
                         if(result.data?.result != null){
                             if(result.data?.code == 2000){
-                                //Log.e("signup-tokens","api 실행 후 : ${tokenStoreViewModel.tokens}")
                                 tokenStoreViewModel.updateAccessToken(result.data.result.accessToken)
                                 tokenStoreViewModel.updateRefreshToken(result.data.result.refreshToken)
-                                //Log.e("signup-tokens","토큰 담은 후 : ${tokenStoreViewModel.tokens}")
+                                Log.e("signup-tokens","토큰 담음 : ${tokenStoreViewModel.tokens}")
+                                printTokens() //token 출력
                             } else {
                                 //토큰 null임
                             }
                         } else { //result가 null 일때
 
                         }
-                        Log.e("signup-tokens", "성공 : ${result.data?.result}")
                     }
                     is Resource.Error ->{
                         Log.e("signup-tokens", "에러 : ${result.message}")


### PR DESCRIPTION
회원가입 최종 post api 완료했습니다. api 응답으로 토큰 받고 database에 넣은 후에 화면 이동하게 구현했습니다. 

logcat에 signup-tokens로 보면 token 담기는 과정 로그로 찍어둔거 확인할 수 있습니다. 이 로그들은 RegisterPreferencesScreen과 AuthScharedViewModel에 있습니다. 참고하세요.! 회원가입할때 전화번호는 01012345678로 고정해놨습니다(전화번호 인증 막아놔서). 그리고 drawer에 있는 userinfoscreen UI랑 화면이동하는 것까지 DrawerNavgraph에 구현해놨습니다. 하현이 참고하면 될 듯해요.!

로그아웃 api는 아직 구현 안했습니다. 내일 할 예정입니다.