### PR TITLE
✨ [FEAT] 레시피 댓글 수정 및 삭제 기능

### DIFF
--- a/app/src/main/java/com/zipdabang/zipdabang_android/common/Exception.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/common/Exception.kt
@@ -1,3 +1,4 @@
 package com.zipdabang.zipdabang_android.common
 
 object TogglePreferenceException: Exception("Toggle failure due to network / io exception")
+object CommentMgtFailureException: Exception("Comment edit/delete failure due to network / io exception")

--- a/app/src/main/java/com/zipdabang/zipdabang_android/common/ResponseBody.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/common/ResponseBody.kt
@@ -1,0 +1,11 @@
+package com.zipdabang.zipdabang_android.common
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseBody<T: Any?>(
+    val isSuccess: Boolean,
+    val code: Int,
+    val message: String,
+    val result: T
+)

--- a/app/src/main/java/com/zipdabang/zipdabang_android/common/ResponseCode.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/common/ResponseCode.kt
@@ -14,6 +14,8 @@ enum class ResponseCode(val responseResult: ResponseResult, val code: Int, val m
     BAD_REQUEST_USER_NOT_EXISTS(ResponseResult.ERROR, 4052, "사용자가 없습니다. 서버 개발자에게 문의하세요."),
     BAD_REQUEST_RECIPE_NOT_EXISTS(ResponseResult.ERROR, 4101, "존재하지 않는 레시피 아이디입니다."),
     BAD_REQUEST_RECIPE_BANNED(ResponseResult.ERROR, 4102, "차단한 사용자의 레시피입니다."),
+    BAD_REQUEST_COMMENT_NOT_EXISTS(ResponseResult.ERROR, 4107, "해당 아이디를 가진 댓글이 존재하지 않습니다."),
+    BAD_REQUEST_COMMENT_NOT_OWNER(ResponseResult.ERROR, 4108, "해당 댓글을 작성한 사용자가 아닙니다."),
     BAD_REQUEST_OWNER_TYPE(ResponseResult.ERROR, 4103, "레시피 작성자 타입이 잘못되었습니다."),
     BAD_REQUEST_INDEX_EXCEEDED(ResponseResult.ERROR, 4055, "페이지 인덱스 범위를 초과했습니다."),
     BAD_REQUEST_INDEX_MINUS(ResponseResult.ERROR, 4054, "인덱스는 1 이상이어야 합니다."),
@@ -21,7 +23,7 @@ enum class ResponseCode(val responseResult: ResponseResult, val code: Int, val m
 
     companion object {
         fun getMessageByCode(code: Int): String {
-            return values().find { it.code == code }!!.message
+            return values().find { it.code == code }?.message ?: "code not exists. unexpected error"
         }
     }
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/common/TabItem.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/common/TabItem.kt
@@ -20,8 +20,8 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
         val recipeId: Int,
         private val onClickReport: (Int) -> Unit,
         private val onClickBlock: (Int) -> Unit,
-        private val onClickEdit: (Int) -> Unit,
-        private val onClickDelete: (Int) -> Unit
+        private val onClickEdit: (Int, Int, String) -> Unit,
+        private val onClickDelete: (Int, Int) -> Unit
     ) : TabItem(
         tabTitle = "댓글 ${comments}개",
         screen = { RecipeCommentPage(

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/Paging3Database.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/Paging3Database.kt
@@ -21,7 +21,7 @@ import com.zipdabang.zipdabang_android.module.search.domain.SearchDao
         RecipeItemEntity::class, SearchRecipe::class,
         RecipeCommentEntity::class
     ],
-    version = 8, exportSchema = false)
+    version = 9, exportSchema = false)
 @TypeConverters(ListConverter::class)
 abstract class Paging3Database : RoomDatabase() {
     abstract fun CategoryDao() : MarketCategoryDao

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/SharedNavGraph.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/SharedNavGraph.kt
@@ -1,11 +1,13 @@
 package com.zipdabang.zipdabang_android.core.navigation
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
+import com.zipdabang.zipdabang_android.module.comment.ui.RecipeCommentViewModel
 import com.zipdabang.zipdabang_android.module.detail.recipe.ui.RecipeDetailScreen
 import com.zipdabang.zipdabang_android.module.market.ui.CategoryMarketScreen
 import com.zipdabang.zipdabang_android.module.search.ui.SearchCategoryScreen
@@ -24,6 +26,9 @@ fun NavGraphBuilder.SharedNavGraph(navController: NavController){
                 navArgument(name = "recipeId") { type = NavType.IntType }
             )
         ) { backStackEntry ->
+
+            val recipeCommentViewModel = hiltViewModel<RecipeCommentViewModel>()
+
             RecipeDetailScreen(
                 navController = navController,
                 recipeId = backStackEntry.arguments?.getInt("recipeId"),
@@ -36,8 +41,12 @@ fun NavGraphBuilder.SharedNavGraph(navController: NavController){
                 onClickReport = { recipeId -> },
                 onClickCommentBlock = { recipeId -> },
                 onClickCommentReport = { recipeId -> },
-                onClickCommentDelete = { recipeId -> },
-                onClickCommentEdit = { recipeId -> },
+                onClickCommentDelete = { recipeId, commentId ->
+                    recipeCommentViewModel.deleteComment(recipeId, commentId)
+                },
+                onClickCommentEdit = { recipeId, commentId, newContent ->
+                    recipeCommentViewModel.editComment(recipeId, commentId, newContent)
+                },
             )
         }
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/common/TextMode.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/common/TextMode.kt
@@ -1,0 +1,5 @@
+package com.zipdabang.zipdabang_android.module.comment.common
+
+enum class TextMode {
+    POST, EDIT;
+}

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/RecipeCommentRepositoryImpl.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/RecipeCommentRepositoryImpl.kt
@@ -5,10 +5,12 @@ import androidx.paging.ExperimentalPagingApi
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import com.zipdabang.zipdabang_android.common.Constants
+import com.zipdabang.zipdabang_android.common.ResponseBody
 import com.zipdabang.zipdabang_android.core.Paging3Database
 import com.zipdabang.zipdabang_android.core.data_store.proto.Token
 import com.zipdabang.zipdabang_android.core.remotekey.RemoteKeys
 import com.zipdabang.zipdabang_android.module.comment.data.local.RecipeCommentEntity
+import com.zipdabang.zipdabang_android.module.comment.data.remote.EditCommentContent
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentContent
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentDto
 import com.zipdabang.zipdabang_android.module.comment.domain.CommentMgtResult
@@ -44,12 +46,33 @@ class RecipeCommentRepositoryImpl @Inject constructor(
     override suspend fun postRecipeComment(
         accessToken: String,
         recipeId: Int,
-        commentBody: PostCommentContent
+        commentBody: String
     ): PostCommentDto {
         return recipeApi.submitRecipeComment(
             accessToken,
             recipeId,
-            commentBody
+            PostCommentContent(commentBody)
+        )
+    }
+
+    override suspend fun deleteRecipeComment(
+        accessToken: String,
+        recipeId: Int,
+        commentId: Int
+    ): ResponseBody<String?> {
+        return recipeApi.deleteRecipeComment(
+            accessToken, recipeId, commentId
+        )
+    }
+
+    override suspend fun editRecipeComment(
+        accessToken: String,
+        recipeId: Int,
+        commentId: Int,
+        newContent: String
+    ): PostCommentDto {
+        return recipeApi.editRecipeComment(
+            accessToken, recipeId, commentId, EditCommentContent(newContent)
         )
     }
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/local/RecipeCommentEntity.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/local/RecipeCommentEntity.kt
@@ -15,7 +15,8 @@ data class RecipeCommentEntity(
     val ownerImage: String,
     val ownerNickname: String,
     val commentId: Int,
-    val ownerId: Int
+    val ownerId: Int,
+    val updatedAt: String
 )
 /*
 TODO 질문사항

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/remote/EditCommentContent.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/remote/EditCommentContent.kt
@@ -1,0 +1,8 @@
+package com.zipdabang.zipdabang_android.module.comment.data.remote
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EditCommentContent(
+    val comment: String
+)

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/remote/PostCommentResult.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/remote/PostCommentResult.kt
@@ -8,5 +8,8 @@ data class PostCommentResult(
     val createdAt: String,
     val isOwner: Boolean,
     val ownerImage: String,
-    val ownerNickname: String
+    val ownerNickname: String,
+    val commentId: Int,
+    val ownerId: Int,
+    val updatedAt: String
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/remote/RecipeComment.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/data/remote/RecipeComment.kt
@@ -8,5 +8,8 @@ data class RecipeComment(
     val createdAt: String,
     val isOwner: Boolean,
     val ownerImage: String,
-    val ownerNickname: String
+    val ownerNickname: String,
+    val commentId: Int,
+    val ownerId: Int,
+    val updatedAt: String
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/domain/PostResult.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/domain/PostResult.kt
@@ -1,8 +1,0 @@
-package com.zipdabang.zipdabang_android.module.comment.domain
-
-data class PostResult(
-    val code: Int,
-    val message: String,
-    val isConnectionSuccessful: Boolean,
-    val isPostSuccessful: Boolean
-)

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/domain/RecipeCommentRepository.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/domain/RecipeCommentRepository.kt
@@ -1,6 +1,7 @@
 package com.zipdabang.zipdabang_android.module.comment.domain
 
 import androidx.paging.Pager
+import com.zipdabang.zipdabang_android.common.ResponseBody
 import com.zipdabang.zipdabang_android.module.comment.data.local.RecipeCommentEntity
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentContent
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentDto
@@ -9,7 +10,20 @@ interface RecipeCommentRepository {
     fun getRecipeComments(recipeId: Int): Pager<Int, RecipeCommentEntity>
 
     suspend fun postRecipeComment(
-        accessToken: String, recipeId: Int, commentBody: PostCommentContent
+        accessToken: String, recipeId: Int, commentBody: String
+    ): PostCommentDto
+
+    suspend fun deleteRecipeComment(
+        accessToken: String,
+        recipeId: Int,
+        commentId: Int
+    ): ResponseBody<String?>
+
+    suspend fun editRecipeComment(
+        accessToken: String,
+        recipeId: Int,
+        commentId: Int,
+        newContent: String
     ): PostCommentDto
 
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/domain/RemoteCommentMgtResult.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/domain/RemoteCommentMgtResult.kt
@@ -1,0 +1,21 @@
+package com.zipdabang.zipdabang_android.module.comment.domain
+
+data class PostResult(
+    val code: Int,
+    val message: String,
+    val isConnectionSuccessful: Boolean,
+    val isPostSuccessful: Boolean
+)
+data class DeleteResult(
+    val code: Int,
+    val message: String,
+    val isConnectionSuccessful: Boolean,
+    val isDeleteSuccessful: Boolean
+)
+
+data class EditResult(
+    val code: Int,
+    val message: String,
+    val isConnectionSuccessful: Boolean,
+    val isEditSuccessful: Boolean
+)

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/CommentListContent.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/CommentListContent.kt
@@ -1,10 +1,7 @@
 package com.zipdabang.zipdabang_android.module.comment.ui
 
 import android.util.Log
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -14,14 +11,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
 import com.zipdabang.zipdabang_android.R
-import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentContent
+import com.zipdabang.zipdabang_android.core.data_store.proto.CurrentPlatform
+import com.zipdabang.zipdabang_android.module.comment.common.TextMode
 import com.zipdabang.zipdabang_android.module.comment.ui.components.CommentItem
 import com.zipdabang.zipdabang_android.module.comment.ui.components.CommentSubmit
 
@@ -31,12 +27,23 @@ fun CommentListContent(
     comments: LazyPagingItems<RecipeCommentState>,
     onClickReport: (Int) -> Unit,
     onClickBlock: (Int) -> Unit,
-    onClickEdit: (Int) -> Unit,
-    onClickDelete: (Int) -> Unit,
+    onClickEdit: (Int, Int, String) -> Unit,
+    onClickDelete: (Int, Int) -> Unit,
     postResult: PostCommentState,
     recipeId: Int
 ) {
 
+    var text by rememberSaveable {
+        mutableStateOf("")
+    }
+
+    var textMode by rememberSaveable {
+        mutableStateOf(TextMode.POST)
+    }
+
+    var currentCommentId by rememberSaveable {
+        mutableStateOf(0)
+    }
 
     LaunchedEffect(key1 = comments.loadState) {
         if (comments.loadState.refresh is LoadState.Loading) {
@@ -59,7 +66,15 @@ fun CommentListContent(
                 isLoading = postResult.isLoading,
                 profileUrl = "https://github.com/kmkim2689/flow-practice/assets/101035437/56eeb15a-f5e3-4b8e-8b5d-993d82d54c5a",
                 recipeId = recipeId,
-                placeHolder = stringResource(id = R.string.placeholder_comment)
+                placeHolder = stringResource(id = R.string.placeholder_comment),
+                currentText = text,
+                textMode = textMode,
+                onEdit = { recipeId, commentId, newContent ->
+                    onClickEdit(recipeId, commentId, newContent)
+                    text = ""
+                    textMode = TextMode.POST
+                },
+                commentId = currentCommentId
             )
         }
 
@@ -74,10 +89,16 @@ fun CommentListContent(
 
             if (commentItem != null) {
                 CommentItem(
+                    recipeId = recipeId,
                     commentItem = commentItem,
                     onClickReport = onClickReport,
                     onClickBlock = onClickBlock,
-                    onClickEdit = onClickEdit,
+                    onClickEdit = { commentId, currentContent ->
+                        Log.d("recipe comment", currentContent)
+                        text = currentContent
+                        textMode = TextMode.EDIT
+                        currentCommentId = commentId
+                    },
                     onClickDelete = onClickDelete
                 )
             }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/DeleteCommentState.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/DeleteCommentState.kt
@@ -1,0 +1,8 @@
+package com.zipdabang.zipdabang_android.module.comment.ui
+
+data class DeleteCommentState(
+    val isLoading: Boolean = false,
+    val isConnectionSuccessful: Boolean? = null,
+    val errorMessage: String? = null,
+    val isDeleteSuccessful: Boolean? = null
+)

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/EditCommentState.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/EditCommentState.kt
@@ -1,0 +1,8 @@
+package com.zipdabang.zipdabang_android.module.comment.ui
+
+data class EditCommentState(
+    val isLoading: Boolean = false,
+    val isConnectionSuccessful: Boolean? = null,
+    val errorMessage: String? = null,
+    val isEditSuccessful: Boolean? = null
+)

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/RecipeCommentPage.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/RecipeCommentPage.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -14,7 +15,16 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.zipdabang.zipdabang_android.R
+import com.zipdabang.zipdabang_android.core.data_store.proto.CurrentPlatform
+import com.zipdabang.zipdabang_android.core.data_store.proto.ProtoDataViewModel
 import com.zipdabang.zipdabang_android.module.comment.ui.components.CommentSubmit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 @Composable
 fun RecipeCommentPage(
@@ -22,13 +32,27 @@ fun RecipeCommentPage(
     recipeId: Int,
     onClickReport: (Int) -> Unit,
     onClickBlock: (Int) -> Unit,
-    onClickEdit: (Int) -> Unit,
-    onClickDelete: (Int) -> Unit
+    onClickEdit: (Int, Int, String) -> Unit,
+    onClickDelete: (Int, Int) -> Unit
 ) {
     val viewModel = hiltViewModel<RecipeCommentViewModel>()
+    val tokenViewModel = hiltViewModel<ProtoDataViewModel>()
     val postResult = viewModel.postResult.collectAsState()
     val comments =
         viewModel.getComments(recipeId).collectAsLazyPagingItems()
+
+/*
+    suspend fun currentPlatform() = withContext(Dispatchers.IO) {
+        tokenViewModel.tokens.first().platformStatus
+    }
+*/
+
+/*    suspend fun getCurrentPlatform(): CurrentPlatform = suspendCoroutine { continuation ->
+        CoroutineScope(Dispatchers.IO).launch {
+            val platform = tokenViewModel.tokens.first().platformStatus
+            continuation.resume(platform)
+        }
+    }*/
 
     Log.d("commentlist", "recipeId : $recipeId")
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/RecipeCommentState.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/RecipeCommentState.kt
@@ -7,5 +7,6 @@ data class RecipeCommentState(
     val ownerImage: String,
     val ownerNickname: String,
     val commentId: Int,
-    val ownerId: Int
+    val ownerId: Int,
+    val updatedAt: String
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/RecipeCommentState.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/RecipeCommentState.kt
@@ -1,6 +1,7 @@
 package com.zipdabang.zipdabang_android.module.comment.ui
 
 data class RecipeCommentState(
+    val itemId: Int,
     val content: String,
     val createdAt: String,
     val isOwner: Boolean,

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/RecipeCommentViewModel.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/RecipeCommentViewModel.kt
@@ -10,6 +10,8 @@ import com.zipdabang.zipdabang_android.common.Resource
 import com.zipdabang.zipdabang_android.core.Paging3Database
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentContent
 import com.zipdabang.zipdabang_android.module.comment.domain.RecipeCommentRepository
+import com.zipdabang.zipdabang_android.module.comment.use_case.DeleteCommentUseCase
+import com.zipdabang.zipdabang_android.module.comment.use_case.EditCommentUseCase
 import com.zipdabang.zipdabang_android.module.comment.use_case.PostCommentUseCase
 import com.zipdabang.zipdabang_android.module.comment.util.toRecipeCommentState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,6 +26,8 @@ import javax.inject.Inject
 @HiltViewModel
 class RecipeCommentViewModel @Inject constructor(
     private val postCommentUseCase: PostCommentUseCase,
+    private val deleteCommentUseCase: DeleteCommentUseCase,
+    private val editCommentUseCase: EditCommentUseCase,
     private val database: Paging3Database,
     private val repository: RecipeCommentRepository
 ): ViewModel() {
@@ -35,6 +39,12 @@ class RecipeCommentViewModel @Inject constructor(
     private val _postResult = MutableStateFlow(PostCommentState())
     val postResult = _postResult.asStateFlow()
     // val postResult = _postResult.collectAsState()
+
+    private val _deleteResult = MutableStateFlow(DeleteCommentState())
+    val deleteResult = _deleteResult.asStateFlow()
+
+    private val _editResult = MutableStateFlow(EditCommentState())
+    val editResult = _editResult.asStateFlow()
 
     fun getComments(
         recipeId: Int
@@ -51,7 +61,7 @@ class RecipeCommentViewModel @Inject constructor(
 
     fun postComment(
         recipeId: Int,
-        commentItem: PostCommentContent
+        commentItem: String
     ) {
         postCommentUseCase(recipeId, commentItem).onEach { result ->
             when (result) {
@@ -88,4 +98,83 @@ class RecipeCommentViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
+    fun deleteComment(
+        recipeId: Int,
+        commentId: Int
+    ) {
+        deleteCommentUseCase(recipeId, commentId).onEach { result ->
+            when (result) {
+                is Resource.Loading -> {
+                    _deleteResult.emit(
+                        DeleteCommentState(
+                            isLoading = true
+                        )
+                    )
+                }
+
+                is Resource.Success -> {
+                    _deleteResult.emit(
+                        DeleteCommentState(
+                            isLoading = false,
+                            isConnectionSuccessful = true,
+                            errorMessage = null,
+                            isDeleteSuccessful = true
+                        )
+                    )
+                }
+
+                is Resource.Error -> {
+                    _deleteResult.emit(
+                        DeleteCommentState(
+                            isLoading = false,
+                            isConnectionSuccessful = true,
+                            errorMessage = result.message,
+                            isDeleteSuccessful = false
+                        )
+                    )
+                    Log.d(TAG, "${deleteResult.value}")
+                }
+            }
+        }.launchIn(viewModelScope)
+    }
+
+    fun editComment(
+        recipeId: Int,
+        commentId: Int,
+        newContent: String
+    ) {
+        editCommentUseCase(recipeId, commentId, newContent).onEach { result ->
+            when (result) {
+                is Resource.Loading -> {
+                    _editResult.emit(
+                        EditCommentState(
+                            isLoading = true
+                        )
+                    )
+                }
+
+                is Resource.Success -> {
+                    _editResult.emit(
+                        EditCommentState(
+                            isLoading = false,
+                            isConnectionSuccessful = true,
+                            errorMessage = null,
+                            isEditSuccessful = true
+                        )
+                    )
+                }
+
+                is Resource.Error -> {
+                    _editResult.emit(
+                        EditCommentState(
+                            isLoading = false,
+                            isConnectionSuccessful = true,
+                            errorMessage = result.message,
+                            isEditSuccessful = false
+                        )
+                    )
+                }
+            }
+        }.launchIn(viewModelScope)
+    }
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentEditButton.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentEditButton.kt
@@ -28,12 +28,13 @@ import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentCon
 import com.zipdabang.zipdabang_android.ui.theme.ZipdabangandroidTheme
 
 @Composable
-fun CommentSubmitButton(
+fun CommentEditButton(
     modifier: Modifier = Modifier,
     isFulfilled: Boolean = false,
     recipeId: Int,
     commentContent: String,
-    onClick: (Int, String) -> Unit
+    commentId: Int,
+    onEdit: (Int, Int, String) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -45,14 +46,14 @@ fun CommentSubmitButton(
             )
             .clickable(enabled = isFulfilled) {
                 if (isFulfilled) {
-                    onClick(recipeId, commentContent)
+                    onEdit(recipeId, commentId, commentContent)
                 }
             },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = stringResource(R.string.btn_register_comment),
+            text = stringResource(R.string.btn_comment_edit),
             color = if (isFulfilled) Color(0xFFE7AC98) else Color(0x80262D31),
             fontFamily = FontFamily(Font(R.font.kopubworlddotum_medium)),
             fontSize = 14.sp
@@ -60,12 +61,3 @@ fun CommentSubmitButton(
     }
 }
 
-@Preview
-@Composable
-fun CommentButtonPreview() {
-    CommentSubmitButton(
-        recipeId = 1,
-        commentContent = "",
-        onClick = { id, content -> }
-    )
-}

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentEditTextField.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentEditTextField.kt
@@ -28,15 +28,18 @@ import com.zipdabang.zipdabang_android.ui.theme.ZipdabangandroidTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CommentTextField(
+fun CommentEditTextField(
     isLoading: Boolean,
     modifier: Modifier = Modifier,
     recipeId: Int,
     value: String,
     onValueChange: (String) -> Unit,
     onSubmit: (Int, String) -> Unit,
+    onEdit: (Int, Int, String) -> Unit,
+    textMode: TextMode,
     isFulfilled: Boolean,
     placeHolder: String,
+    commentId: Int
 ) {
     OutlinedTextField(
         modifier = modifier
@@ -69,12 +72,22 @@ fun CommentTextField(
                     color = ZipdabangandroidTheme.Colors.Choco
                 )
             } else {
-                CommentSubmitButton(
-                    recipeId = recipeId,
-                    commentContent = value,
-                    onClick = onSubmit,
-                    isFulfilled = isFulfilled
-                )
+                if (textMode == TextMode.POST) {
+                    CommentSubmitButton(
+                        recipeId = recipeId,
+                        commentContent = value,
+                        onClick = onSubmit,
+                        isFulfilled = isFulfilled
+                    )
+                } else {
+                    CommentEditButton(
+                        recipeId = recipeId,
+                        commentContent = value,
+                        onEdit = onEdit,
+                        isFulfilled = isFulfilled,
+                        commentId = commentId
+                    )
+                }
             }
         }
     )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentItem.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -138,7 +139,7 @@ fun CommentItem(
                     }
 
                     DropdownMenu(
-                        modifier = Modifier.background(ZipdabangandroidTheme.Colors.MainBackground),
+                        modifier = Modifier.background(Color.White),
                         expanded = isExpandedForOwner,
                         onDismissRequest = { isExpandedForOwner = false },
                     ) {
@@ -154,6 +155,25 @@ fun CommentItem(
                             onClick = {
                                 onClickEdit(commentItem.commentId, commentItem.content)
                                 isExpandedForOwner = !isExpandedForOwner
+                            }
+                        )
+                    }
+
+                    DropdownMenu(
+                        modifier = Modifier.background(Color.White),
+                        expanded = isExpandedForNotOwner,
+                        onDismissRequest = { isExpandedForNotOwner = false },
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("신고하기") },
+                            onClick = {
+
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("차단하기") },
+                            onClick = {
+
                             }
                         )
                     }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentItem.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentItem.kt
@@ -1,19 +1,28 @@
 package com.zipdabang.zipdabang_android.module.comment.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -21,23 +30,41 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.zipdabang.zipdabang_android.R
+import com.zipdabang.zipdabang_android.core.data_store.proto.CurrentPlatform
+import com.zipdabang.zipdabang_android.core.data_store.proto.ProtoDataViewModel
 import com.zipdabang.zipdabang_android.module.comment.ui.RecipeCommentState
 import com.zipdabang.zipdabang_android.ui.component.CircleImage
 import com.zipdabang.zipdabang_android.ui.theme.DialogGray
 import com.zipdabang.zipdabang_android.ui.theme.ZipdabangandroidTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun CommentItem(
+    recipeId: Int,
     commentItem: RecipeCommentState,
     onClickReport: (Int) -> Unit,
     onClickBlock: (Int) -> Unit,
-    onClickEdit: (Int) -> Unit,
-    onClickDelete: (Int) -> Unit
+    // 여기서 onClickEdit은 textfield 활성화를 의미
+    onClickEdit: (Int, String) -> Unit,
+    onClickDelete: (Int, Int) -> Unit
 ) {
+    val tokenViewModel = hiltViewModel<ProtoDataViewModel>()
+
+    suspend fun currentPlatform() = withContext(Dispatchers.IO) {
+        tokenViewModel.tokens.first().platformStatus
+    }
+
+    var isExpandedForOwner by remember { mutableStateOf(false) }
+    var isExpandedForNotOwner by remember { mutableStateOf(false) }
+
     Row(
         modifier = Modifier.fillMaxWidth()
     ) {
@@ -84,23 +111,55 @@ fun CommentItem(
                     )
                 }
 
-                IconButton(
-                    modifier = Modifier.size(18.dp),
-                    onClick = {
-                        if (commentItem.isOwner) {
-
-                        } else {
-
+                Box(modifier = Modifier.size(18.dp).wrapContentSize(Alignment.TopEnd)) {
+                    IconButton(
+                        modifier = Modifier.fillMaxSize(),
+                        onClick = {
+                            CoroutineScope(Dispatchers.Main).launch {
+                                val currentPlatform = currentPlatform()
+                                if (currentPlatform == CurrentPlatform.NONE
+                                    || currentPlatform == CurrentPlatform.TEMP) {
+                                    // 온보딩으로 이동
+                                } else {
+                                    if (commentItem.isOwner) {
+                                        isExpandedForOwner = !isExpandedForOwner
+                                    } else {
+                                        isExpandedForNotOwner = !isExpandedForNotOwner
+                                    }
+                                }
+                            }
                         }
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.all_more_white),
+                            contentDescription = "comment menu",
+                            tint = ZipdabangandroidTheme.Colors.Typo
+                        )
                     }
-                ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.all_more_white),
-                        contentDescription = "comment menu",
-                        tint = ZipdabangandroidTheme.Colors.Typo
-                    )
+
+                    DropdownMenu(
+                        modifier = Modifier.background(ZipdabangandroidTheme.Colors.MainBackground),
+                        expanded = isExpandedForOwner,
+                        onDismissRequest = { isExpandedForOwner = false },
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("댓글 삭제하기") },
+                            onClick = {
+                                onClickDelete(recipeId, commentItem.commentId)
+                                isExpandedForOwner = !isExpandedForOwner
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("댓글 수정하기") },
+                            onClick = {
+                                onClickEdit(commentItem.commentId, commentItem.content)
+                                isExpandedForOwner = !isExpandedForOwner
+                            }
+                        )
+                    }
                 }
             }
+
 
             Spacer(modifier = Modifier.height(2.dp))
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentSubmit.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/ui/components/CommentSubmit.kt
@@ -1,5 +1,6 @@
 package com.zipdabang.zipdabang_android.module.comment.ui.components
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,6 +31,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.zipdabang.zipdabang_android.R
+import com.zipdabang.zipdabang_android.common.CommentMgtFailureException
+import com.zipdabang.zipdabang_android.module.comment.common.TextMode
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentContent
 import com.zipdabang.zipdabang_android.module.comment.ui.RecipeCommentState
 import com.zipdabang.zipdabang_android.module.comment.ui.RecipeCommentViewModel
@@ -40,23 +44,31 @@ fun CommentSubmit(
     isLoading: Boolean,
     profileUrl: String,
     recipeId: Int,
-    placeHolder: String
+    placeHolder: String,
+    textMode: TextMode,
+    onEdit: (Int, Int, String) -> Unit,
+    commentId: Int = 0,
+    currentText: String
 ) {
+
+    Log.d("recipe comment", "current value inner textfield : $currentText")
+    Log.d("recipe comment", "current commentId : $commentId")
+
 
     val viewModel = hiltViewModel<RecipeCommentViewModel>()
 
-    var text by rememberSaveable {
-        mutableStateOf("")
-    }
-    
-    val isFulfilled by remember {
-        derivedStateOf {
-            text.length in 1..100
-        }
+    val editState = viewModel.editResult.collectAsState()
+    val deleteState = viewModel.deleteResult.collectAsState()
+
+    if (editState.value.errorMessage != null
+        || deleteState.value.errorMessage != null) {
+        throw CommentMgtFailureException
     }
 
     Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 20.dp)
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 20.dp)
     ) {
         Box(
             modifier = Modifier.size(40.dp)
@@ -66,25 +78,80 @@ fun CommentSubmit(
 
         Spacer(modifier = Modifier.width(8.dp))
 
-        CommentTextField(
-            isLoading = isLoading,
-            recipeId = recipeId,
-            value = text,
-            onValueChange = { changedValue ->
-                if (changedValue.length in 0..100) {
-                    text = changedValue
+        if (textMode == TextMode.EDIT && commentId != 0) {
+            var text by rememberSaveable {
+                mutableStateOf(currentText)
+            }
+            Log.d("recipe comment", "edit entered : $text")
+
+            val isFulfilled by remember {
+                derivedStateOf {
+                    text.length in 1..100
                 }
-            },
-            onSubmit = { recipeId, content ->
-                viewModel.postComment(recipeId, content)
-                text = ""
-            },
-            isFulfilled = isFulfilled,
-            placeHolder = placeHolder
-        )
+            }
+            CommentEditTextField(
+                isLoading = isLoading,
+                recipeId = recipeId,
+                value = text,
+                onValueChange = { changedValue ->
+                    if (changedValue.length in 0..100) {
+                        text = changedValue
+                    }
+                },
+                onSubmit = { recipeId, content ->
+                    try {
+                        viewModel.editComment(recipeId, commentId, content)
+                        text = ""
+                    } catch (e: CommentMgtFailureException) {
+                        Log.d("comment submit", "edit failure")
+                    } catch (e: Exception) {
+                        Log.d("comment submit", "unknown failure : ${e.message}")
+                    }
+
+                },
+                isFulfilled = isFulfilled,
+                placeHolder = placeHolder,
+                textMode = textMode,
+                onEdit = onEdit,
+                commentId = commentId
+            )
+        } else {
+            var text by rememberSaveable {
+                mutableStateOf("")
+            }
+
+            val isFulfilled by remember {
+                derivedStateOf {
+                    text.length in 1..100
+                }
+            }
+            CommentTextField(
+                isLoading = isLoading,
+                recipeId = recipeId,
+                value = text,
+                onValueChange = { changedValue ->
+                    if (changedValue.length in 0..100) {
+                        text = changedValue
+                    }
+                },
+                onSubmit = { recipeId, content ->
+                    try {
+                        viewModel.postComment(recipeId, content)
+                        text = ""
+                    } catch (e: CommentMgtFailureException) {
+                        Log.d("comment submit", "edit failure")
+                    } catch (e: Exception) {
+                        Log.d("comment submit", "unknown failure : ${e.message}")
+                    }
+                },
+                isFulfilled = isFulfilled,
+                placeHolder = placeHolder
+            )
+        }
     }
 }
 
+/*
 @Preview
 @Composable
 fun CommentSubmitPreview() {
@@ -94,4 +161,4 @@ fun CommentSubmitPreview() {
         placeHolder = "Asdf",
         isLoading = true
     )
-}
+}*/

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/use_case/DeleteCommentUseCase.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/use_case/DeleteCommentUseCase.kt
@@ -1,0 +1,56 @@
+package com.zipdabang.zipdabang_android.module.comment.use_case
+
+import androidx.datastore.core.DataStore
+import com.zipdabang.zipdabang_android.common.Resource
+import com.zipdabang.zipdabang_android.common.ResponseCode
+import com.zipdabang.zipdabang_android.core.data_store.proto.Token
+import com.zipdabang.zipdabang_android.module.comment.domain.DeleteResult
+import com.zipdabang.zipdabang_android.module.comment.domain.RecipeCommentRepository
+import com.zipdabang.zipdabang_android.module.comment.util.toDeleteResult
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import retrofit2.HttpException
+import java.io.IOException
+import java.util.concurrent.CancellationException
+import javax.inject.Inject
+
+class DeleteCommentUseCase @Inject constructor(
+    private val repository: RecipeCommentRepository,
+    private val tokenDataStore: DataStore<Token>
+) {
+    operator fun invoke(
+        recipeId: Int,
+        commentId: Int
+    ) = flow {
+        try {
+            emit(Resource.Loading())
+
+            val accessToken = "Bearer ${tokenDataStore.data.first().accessToken}"
+            val result = repository.deleteRecipeComment(
+                accessToken = accessToken,
+                recipeId = recipeId,
+                commentId = commentId
+            ).toDeleteResult()
+
+            when (result.code) {
+                ResponseCode.RESPONSE_DEFAULT.code -> {
+                    emit(Resource.Success(data = result, code = result.code, message = result.message))
+                }
+                else -> {
+                    val message = ResponseCode.getMessageByCode(result.code)
+                    emit(Resource.Error(message = message))
+                }
+            }
+
+        } catch (e: HttpException) {
+            emit(Resource.Error(e.message ?: "unexpected http error"))
+        } catch (e: IOException) {
+            emit(Resource.Error(e.message ?: "unexpected io error"))
+        } catch (e: Exception) {
+            if (e is CancellationException) {
+                throw e
+            }
+            emit(Resource.Error(e.message ?: "unexpected error"))
+        }
+    }
+}

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/use_case/EditCommentUseCase.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/use_case/EditCommentUseCase.kt
@@ -1,0 +1,59 @@
+package com.zipdabang.zipdabang_android.module.comment.use_case
+
+import androidx.datastore.core.DataStore
+import com.zipdabang.zipdabang_android.common.Resource
+import com.zipdabang.zipdabang_android.common.ResponseCode
+import com.zipdabang.zipdabang_android.core.data_store.proto.Token
+import com.zipdabang.zipdabang_android.module.comment.domain.EditResult
+import com.zipdabang.zipdabang_android.module.comment.domain.RecipeCommentRepository
+import com.zipdabang.zipdabang_android.module.comment.util.toEditResult
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import retrofit2.HttpException
+import java.io.IOException
+import java.util.concurrent.CancellationException
+import javax.inject.Inject
+
+class EditCommentUseCase @Inject constructor(
+    private val repository: RecipeCommentRepository,
+    private val tokenDataStore: DataStore<Token>
+) {
+    operator fun invoke(
+        recipeId: Int,
+        commentId: Int,
+        newContent: String
+    ) = flow<Resource<EditResult>> {
+        try {
+            emit(Resource.Loading())
+
+            val accessToken = "Bearer ${tokenDataStore.data.first().accessToken}"
+
+            val result = repository.editRecipeComment(
+                accessToken = accessToken,
+                recipeId = recipeId,
+                commentId = commentId,
+                newContent = newContent
+            ).toEditResult()
+
+            when (result.code) {
+                ResponseCode.RESPONSE_DEFAULT.code -> {
+                    emit(Resource.Success(data = result, code = result.code, message = result.message))
+                }
+                else -> {
+                    val message = ResponseCode.getMessageByCode(result.code)
+                    emit(Resource.Error(message = message))
+                }
+            }
+
+        } catch (e: HttpException) {
+            emit(Resource.Error(e.message ?: "unexpected http error"))
+        } catch (e: IOException) {
+            emit(Resource.Error(e.message ?: "unexpected io error"))
+        } catch (e: Exception) {
+            if (e is CancellationException) {
+                throw e
+            }
+            emit(Resource.Error(e.message ?: "unexpected error"))
+        }
+    }
+}

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/use_case/InsertCommentItemUseCase.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/use_case/InsertCommentItemUseCase.kt
@@ -3,11 +3,9 @@ package com.zipdabang.zipdabang_android.module.comment.use_case
 import com.zipdabang.zipdabang_android.common.Resource
 import com.zipdabang.zipdabang_android.module.comment.domain.CommentMgtResult
 import com.zipdabang.zipdabang_android.module.comment.domain.RecipeCommentRepository
-import com.zipdabang.zipdabang_android.module.comment.ui.PostCommentState
 import com.zipdabang.zipdabang_android.module.comment.ui.RecipeCommentState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.flow
-import java.io.IOException
 import javax.inject.Inject
 
 class InsertCommentItemUseCase @Inject constructor(

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/use_case/PostCommentUseCase.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/use_case/PostCommentUseCase.kt
@@ -19,7 +19,7 @@ class PostCommentUseCase @Inject constructor(
     private val tokenDataStore: DataStore<Token>
 ) {
     operator fun invoke(
-        recipeId: Int, commentBody: PostCommentContent
+        recipeId: Int, commentBody: String
     ) = flow {
         try {
             val accessToken = ("Bearer " + tokenDataStore.data.first().accessToken)

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/util/RecipeCommentMapper.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/util/RecipeCommentMapper.kt
@@ -26,6 +26,7 @@ fun RecipeComment.toRecipeCommentEntity(): RecipeCommentEntity {
 
 fun RecipeCommentEntity.toRecipeCommentState(): RecipeCommentState {
     return RecipeCommentState(
+        itemId = itemId,
         content = content,
         createdAt = createdAt,
         isOwner = isOwner,
@@ -39,7 +40,7 @@ fun RecipeCommentEntity.toRecipeCommentState(): RecipeCommentState {
 
 fun RecipeCommentState.toRecipeCommentEntity(): RecipeCommentEntity {
     return RecipeCommentEntity(
-        itemId = 0,
+        itemId = itemId,
         content = content,
         createdAt = createdAt,
         isOwner = isOwner,

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/util/RecipeCommentMapper.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/comment/util/RecipeCommentMapper.kt
@@ -1,8 +1,11 @@
 package com.zipdabang.zipdabang_android.module.comment.util
 
+import com.zipdabang.zipdabang_android.common.ResponseBody
 import com.zipdabang.zipdabang_android.module.comment.data.local.RecipeCommentEntity
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentDto
 import com.zipdabang.zipdabang_android.module.comment.data.remote.RecipeComment
+import com.zipdabang.zipdabang_android.module.comment.domain.DeleteResult
+import com.zipdabang.zipdabang_android.module.comment.domain.EditResult
 import com.zipdabang.zipdabang_android.module.comment.domain.PostResult
 import com.zipdabang.zipdabang_android.module.comment.ui.RecipeCommentState
 import java.util.Random
@@ -15,9 +18,9 @@ fun RecipeComment.toRecipeCommentEntity(): RecipeCommentEntity {
         isOwner = isOwner,
         ownerImage = ownerImage,
         ownerNickname = ownerNickname,
-        // TODO commentId와 ownerId 요구하여 고치기
-        commentId = ThreadLocalRandom.current().nextInt(1, 100000),
-        ownerId = ThreadLocalRandom.current().nextInt(1, 100000)
+        commentId = commentId,
+        ownerId = ownerId,
+        updatedAt = updatedAt
     )
 }
 
@@ -29,7 +32,8 @@ fun RecipeCommentEntity.toRecipeCommentState(): RecipeCommentState {
         ownerImage = ownerImage,
         ownerNickname = ownerNickname,
         commentId = commentId,
-        ownerId = ownerId
+        ownerId = ownerId,
+        updatedAt = updatedAt
     )
 }
 
@@ -42,7 +46,8 @@ fun RecipeCommentState.toRecipeCommentEntity(): RecipeCommentEntity {
         ownerImage = ownerImage,
         ownerNickname = ownerNickname,
         commentId = commentId,
-        ownerId = ownerId
+        ownerId = ownerId,
+        updatedAt = updatedAt
     )
 }
 
@@ -52,5 +57,23 @@ fun PostCommentDto.toPostResult(): PostResult {
         message = message,
         isConnectionSuccessful = isSuccess,
         isPostSuccessful = result != null
+    )
+}
+
+fun PostCommentDto.toEditResult(): EditResult {
+    return EditResult(
+        code = code,
+        message = message,
+        isConnectionSuccessful = isSuccess,
+        isEditSuccessful = result != null
+    )
+}
+
+fun ResponseBody<String?>.toDeleteResult(): DeleteResult {
+    return DeleteResult(
+        code = code,
+        message = message,
+        isConnectionSuccessful = isSuccess,
+        isDeleteSuccessful = result != null
     )
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/ui/RecipeDetailScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/ui/RecipeDetailScreen.kt
@@ -46,8 +46,8 @@ fun RecipeDetailScreen(
     onClickEdit: (Int) -> Unit,
     onClickCommentReport: (Int) -> Unit,
     onClickCommentBlock: (Int) -> Unit,
-    onClickCommentEdit: (Int) -> Unit,
-    onClickCommentDelete: (Int) -> Unit
+    onClickCommentEdit: (Int, Int, String) -> Unit,
+    onClickCommentDelete: (Int, Int) -> Unit
 ){
 
     Log.d("RecipeDetail", "$recipeId")
@@ -183,6 +183,7 @@ fun RecipeDetailScreen(
                         onClickReport = onClickCommentReport,
                         onClickBlock = onClickCommentBlock,
                         onClickDelete = onClickCommentDelete,
+                        // 제출
                         onClickEdit = onClickCommentEdit
                     )
                 ),
@@ -192,4 +193,5 @@ fun RecipeDetailScreen(
 
         }
     }
+
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/data/RecipeApi.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/data/RecipeApi.kt
@@ -1,5 +1,7 @@
 package com.zipdabang.zipdabang_android.module.recipes.data
 
+import com.zipdabang.zipdabang_android.common.ResponseBody
+import com.zipdabang.zipdabang_android.module.comment.data.remote.EditCommentContent
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentContent
 import com.zipdabang.zipdabang_android.module.comment.data.remote.PostCommentDto
 import com.zipdabang.zipdabang_android.module.comment.data.remote.RecipeCommentDto
@@ -10,8 +12,10 @@ import com.zipdabang.zipdabang_android.module.recipes.data.preference.Preference
 import com.zipdabang.zipdabang_android.module.recipes.data.preview.RecipePreviewItemsDto
 import com.zipdabang.zipdabang_android.module.recipes.data.recipe_list.RecipeListDto
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -88,5 +92,20 @@ interface RecipeApi {
         @Header("Authorization") accessToken: String,
         @Path("recipeId") recipeId: Int,
         @Body content: PostCommentContent
+    ): PostCommentDto
+
+    @DELETE("members/recipes/{recipeId}/{commentId}")
+    suspend fun deleteRecipeComment(
+        @Header("Authorization") accessToken: String,
+        @Path("recipeId") recipeId: Int,
+        @Path("commentId") commentId: Int
+    ): ResponseBody<String?>
+
+    @PATCH("members/recipes/{recipeId}/{commentId}")
+    suspend fun editRecipeComment(
+        @Header("Authorization") accessToken: String,
+        @Path("recipeId") recipeId: Int,
+        @Path("commentId") commentId: Int,
+        @Body comment: EditCommentContent
     ): PostCommentDto
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,5 +137,6 @@
     <string name="btn_register_comment">등록</string>
     <string name="placeholder_comment">댓글 쓰기 (최대 100자)</string>
     <string name="group_header_recipe_of">의 레시피</string>
+    <string name="btn_comment_edit">수정</string>
 
 </resources>


### PR DESCRIPTION
### 🚩 관련 이슈
레시피 댓글의 수정과 삭제 기능을 구현

### 📋 PR Checklist
- [ ] 분기처리를 통하여 댓글을 작성한 사용자일때만 댓글 수정/삭제 드롭다운 메뉴를 볼 수 있도록 조치 -> 작성자일 때만 수정/삭제할 수 있도록 함
- [ ] 댓글을 수정했을 때와 삭제했을 때, api에 반영됨과 동시에 로컬 database에서도 즉각 반영되도록 구현
- [ ] 댓글 수정 시 텍스트 필드 입력이 새로운 댓글 입력으로 이어지지 않도록 구현

### 📌 유의사항
위와 같음

### ✅ 테스트 결과
모두 정상적으로 동작해야 합니다. 
