### PR TITLE
♻️🐛 [FIX] 로그아웃 api 매개변수 수정

### DIFF
--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/my/data/remote/MyApi.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/my/data/remote/MyApi.kt
@@ -7,7 +7,6 @@ import retrofit2.http.POST
 interface MyApi {
     @POST("members/logout")
     suspend fun signOut(
-        @Header("Authorization") accessToken: String,
-        @Body tokensForSignOut: SignOutTokens
+        @Header("Authorization") accessToken: String
     ): SignOutResponseDto
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/my/data/repository/MyRepositoryImpl.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/my/data/repository/MyRepositoryImpl.kt
@@ -9,10 +9,7 @@ import javax.inject.Inject
 class MyRepositoryImpl @Inject constructor(
     private val api : MyApi
 ) : MyRepository{
-    override suspend fun signOut(
-        accessToken: String,
-        signOutTokens: SignOutTokens
-    ): SignOutResponseDto {
-        return api.signOut(accessToken, signOutTokens)
+    override suspend fun signOut(accessToken: String, ): SignOutResponseDto {
+        return api.signOut(accessToken)
     }
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/my/di/MyModule.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/my/di/MyModule.kt
@@ -8,6 +8,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
@@ -21,6 +23,9 @@ object MyModule {
         return Retrofit.Builder()
             .baseUrl(Constants.BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
+            .client(OkHttpClient.Builder().addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            }).build())
             .build()
             .create(MyApi::class.java)
     }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/my/domain/repository/MyRepository.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/my/domain/repository/MyRepository.kt
@@ -4,5 +4,5 @@ import com.zipdabang.zipdabang_android.module.my.data.remote.SignOutResponseDto
 import com.zipdabang.zipdabang_android.module.my.data.remote.SignOutTokens
 
 interface MyRepository {
-    suspend fun signOut(accessToken: String, signOutTokens: SignOutTokens): SignOutResponseDto
+    suspend fun signOut(accessToken: String): SignOutResponseDto
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/my/ui/viewmodel/MyViewModel.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/my/ui/viewmodel/MyViewModel.kt
@@ -36,6 +36,7 @@ class MyViewModel @Inject constructor(
         onSignOutSuccessful: () -> Unit
     ) {
         signOutUseCase().onEach { resource ->
+            Log.d("logout viewmodel", "usecase called")
             when (resource) {
                 is Resource.Loading -> {
                     _signOutState.value = SignOutState(
@@ -45,34 +46,23 @@ class MyViewModel @Inject constructor(
 
                 is Resource.Success -> {
                     Log.d("Logout", resource.data.toString())
-                    try {
-                        _signOutState.value = SignOutState(
-                            isLoading = false,
-                            isSuccessful = true
+                    _signOutState.value = SignOutState(
+                        isLoading = false,
+                        isSuccessful = true
+                    )
+
+                    dataStore.updateData {
+                        it.copy(
+                            accessToken = null,
+                            refreshToken = null,
+                            platformToken = null,
+                            platformStatus = CurrentPlatform.NONE
                         )
-
-                        dataStore.updateData {
-                            it.copy(
-                                accessToken = null,
-                                refreshToken = null,
-                                platformToken = null,
-                                platformStatus = CurrentPlatform.NONE
-                            )
-                        }
-
-                        onSignOutSuccessful()
-                    } catch (e: Exception) {
-                        if (e is CancellationException) {
-                            throw e
-                        } else {
-                            _signOutState.value = SignOutState(
-                                isLoading = false,
-                                errorMessage = e.message,
-                                isSuccessful = false
-                            )
-                        }
                     }
+
+                    onSignOutSuccessful()
                 }
+
 
                 is Resource.Error -> {
                     Log.d("Logout", "error ${resource.code} : ${resource.message}")

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/my/use_case/SignOutUseCase.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/my/use_case/SignOutUseCase.kt
@@ -28,31 +28,16 @@ class SignOutUseCase @Inject constructor(
 
             val tokens = tokenDataStore.data.first()
             val accessToken = "Bearer ${tokens.accessToken}"
-            val refreshToken = tokens.refreshToken ?: TOKEN_NULL
-            val fcmToken = tokens.fcmToken ?: TOKEN_NULL
-            val deviceNumber = tokens.deviceNumber ?: TOKEN_NULL
 
             Log.d("logout", "tokens : $tokens")
 
-            val tokensForSignOut = SignOutTokens(
-                fcmToken = fcmToken,
-                serialNumber = deviceNumber
-            )
-
-            Log.d("logout", "${repository.signOut(
-                accessToken = accessToken,
-                signOutTokens = tokensForSignOut
-            )}")
-
-            val result = repository.signOut(
-                accessToken = accessToken,
-                signOutTokens = tokensForSignOut
-            ).toSignOutResponse()
+            val result = repository.signOut(accessToken = accessToken).toSignOutResponse()
 
             Log.d("result", result.code.toString())
 
             when (result.code) {
                 ResponseCode.RESPONSE_DEFAULT.code -> {
+                    Log.d("logout", "sign out successful")
                     emit(
                         Resource.Success(
                             code = result.code,
@@ -63,6 +48,7 @@ class SignOutUseCase @Inject constructor(
                 }
 
                 else -> {
+                    Log.d("logout", "sign out failure ${result.code}")
                     emit(
                         Resource.Error(
                             message = ResponseCode.getMessageByCode(result.code),
@@ -72,14 +58,14 @@ class SignOutUseCase @Inject constructor(
                 }
             }
         } catch (e: HttpException) {
-            emit(Resource.Error(e.message ?: "unexpected http exception"))
+            emit(Resource.Error("${e.message} ${e.stackTrace} ${e.localizedMessage}" ?: "unexpected http exception"))
         } catch (e: IOException) {
-            emit(Resource.Error(e.message ?: "unexpected io exception"))
+            emit(Resource.Error("${e.message} ${e.stackTrace}" ?: "unexpected io exception"))
         } catch (e: Exception) {
             if (e is CancellationException) {
                 throw e
             } else {
-                emit(Resource.Error("unexpected error : ${e.message}"))
+                emit(Resource.Error("unexpected error : ${e.message} ${e.printStackTrace()}"))
             }
         }
     }


### PR DESCRIPTION
### 🚩 관련 이슈
로그아웃 api 매개변수 수정 : fcmToken과 deviceNumber 제거

### 📋 PR Checklist
- [ ] 로그아웃 후 온보딩으로 화면 이동이 잘 이뤄지는가
- [ ] 로그아웃 후 애플리케이션 재실행 시 온보딩 화면으로 잘 이동하는가
- [ ] 로그인 후 30분이 지나 access token 만료 시 refresh token으로 access token을 재발급 하는 것이 잘 이뤄지는지 확인 필요

### 📌 유의사항
위와 같음

### ✅ 테스트 결과
정상적으로 동작