### PR TITLE
✨💄 [FEAT] 인기 레시피에서 차단된 사용자의 레시피 클릭 시 알림창 표출

### DIFF
--- a/app/src/main/java/com/zipdabang/zipdabang_android/common/TabItem.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/common/TabItem.kt
@@ -150,6 +150,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
     class Coffee(
         hotItems:  UiState<List<HotRecipeItem>>,
         onRecipeClick: (Int) -> Unit,
+        onBlockedRecipeClick: (Int, Int) -> Unit,
         onScrapClick: (Int) -> Unit,
         onLikeClick: (Int) -> Unit,
         likeState: PreferenceToggleState,
@@ -163,6 +164,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
             HotRecipeList(
                 hotItems = hotItems,
                 onRecipeClick = onRecipeClick,
+                onBlockedRecipeClick = onBlockedRecipeClick,
                 onScrapClick = onScrapClick,
                 onLikeClick = onLikeClick,
                 likeState = likeState,
@@ -177,6 +179,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
     class CaffeineFree(
         hotItems:  UiState<List<HotRecipeItem>>,
         onRecipeClick: (Int) -> Unit,
+        onBlockedRecipeClick: (Int, Int) -> Unit,
         onScrapClick: (Int) -> Unit,
         onLikeClick: (Int) -> Unit,
         likeState: PreferenceToggleState,
@@ -190,6 +193,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
             HotRecipeList(
                 hotItems = hotItems,
                 onRecipeClick = onRecipeClick,
+                onBlockedRecipeClick = onBlockedRecipeClick,
                 onScrapClick = onScrapClick,
                 onLikeClick = onLikeClick,
                 likeState = likeState,
@@ -204,6 +208,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
     class Tea(
         hotItems:  UiState<List<HotRecipeItem>>,
         onRecipeClick: (Int) -> Unit,
+        onBlockedRecipeClick: (Int, Int) -> Unit,
         onScrapClick: (Int) -> Unit,
         onLikeClick: (Int) -> Unit,
         likeState: PreferenceToggleState,
@@ -217,6 +222,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
             HotRecipeList(
                 hotItems = hotItems,
                 onRecipeClick = onRecipeClick,
+                onBlockedRecipeClick = onBlockedRecipeClick,
                 onScrapClick = onScrapClick,
                 onLikeClick = onLikeClick,
                 likeState = likeState,
@@ -231,6 +237,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
     class Ade(
         hotItems:  UiState<List<HotRecipeItem>>,
         onRecipeClick: (Int) -> Unit,
+        onBlockedRecipeClick: (Int, Int) -> Unit,
         onScrapClick: (Int) -> Unit,
         onLikeClick: (Int) -> Unit,
         likeState: PreferenceToggleState,
@@ -244,6 +251,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
             HotRecipeList(
                 hotItems = hotItems,
                 onRecipeClick = onRecipeClick,
+                onBlockedRecipeClick = onBlockedRecipeClick,
                 onScrapClick = onScrapClick,
                 onLikeClick = onLikeClick,
                 likeState = likeState,
@@ -258,6 +266,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
     class Smoothie(
         hotItems:  UiState<List<HotRecipeItem>>,
         onRecipeClick: (Int) -> Unit,
+        onBlockedRecipeClick: (Int, Int) -> Unit,
         onScrapClick: (Int) -> Unit,
         onLikeClick: (Int) -> Unit,
         likeState: PreferenceToggleState,
@@ -271,6 +280,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
             HotRecipeList(
                 hotItems = hotItems,
                 onRecipeClick = onRecipeClick,
+                onBlockedRecipeClick = onBlockedRecipeClick,
                 onScrapClick = onScrapClick,
                 onLikeClick = onLikeClick,
                 likeState = likeState,
@@ -285,6 +295,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
     class Fruit(
         hotItems:  UiState<List<HotRecipeItem>>,
         onRecipeClick: (Int) -> Unit,
+        onBlockedRecipeClick: (Int, Int) -> Unit,
         onScrapClick: (Int) -> Unit,
         onLikeClick: (Int) -> Unit,
         likeState: PreferenceToggleState,
@@ -298,6 +309,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
             HotRecipeList(
                 hotItems = hotItems,
                 onRecipeClick = onRecipeClick,
+                onBlockedRecipeClick = onBlockedRecipeClick,
                 onScrapClick = onScrapClick,
                 onLikeClick = onLikeClick,
                 likeState = likeState,
@@ -312,6 +324,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
     class WellBeing(
         hotItems:  UiState<List<HotRecipeItem>>,
         onRecipeClick: (Int) -> Unit,
+        onBlockedRecipeClick: (Int, Int) -> Unit,
         onScrapClick: (Int) -> Unit,
         onLikeClick: (Int) -> Unit,
         likeState: PreferenceToggleState,
@@ -325,6 +338,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
             HotRecipeList(
                 hotItems = hotItems,
                 onRecipeClick = onRecipeClick,
+                onBlockedRecipeClick = onBlockedRecipeClick,
                 onScrapClick = onScrapClick,
                 onLikeClick = onLikeClick,
                 likeState = likeState,
@@ -339,6 +353,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
     class All(
         hotItems:  UiState<List<HotRecipeItem>>,
         onRecipeClick: (Int) -> Unit,
+        onBlockedRecipeClick: (Int, Int) -> Unit,
         onScrapClick: (Int) -> Unit,
         onLikeClick: (Int) -> Unit,
         likeState: PreferenceToggleState,
@@ -352,6 +367,7 @@ sealed class TabItem(val tabTitle: String, val screen: ComposableFun) {
             HotRecipeList(
                 hotItems = hotItems,
                 onRecipeClick = onRecipeClick,
+                onBlockedRecipeClick = onBlockedRecipeClick,
                 onScrapClick = onScrapClick,
                 onLikeClick = onLikeClick,
                 likeState = likeState,

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/RecipeNavGraph.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/RecipeNavGraph.kt
@@ -48,6 +48,13 @@ fun NavGraphBuilder.RecipeNavGraph(
                         launchSingleTop = true
                     }
                 },
+                onBlockedRecipeClick = { recipeId, ownerId ->
+                    navController.navigate(
+                        route = SharedScreen.BlockedRecipe.passRecipeId(recipeId, ownerId)
+                    ) {
+                        launchSingleTop = true
+                    }
+                },
                 onBannerClick = { keyword ->
 
                 },

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/Screen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/Screen.kt
@@ -105,5 +105,11 @@ sealed class SharedScreen(val route : String){
         }
     }
 
+    object BlockedRecipe: SharedScreen(route = "shared/detail/blocked/{recipeId}") {
+        fun passRecipeId(recipeId: Int): String{
+            return "shared/detail/blocked/$recipeId"
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/Screen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/Screen.kt
@@ -105,9 +105,9 @@ sealed class SharedScreen(val route : String){
         }
     }
 
-    object BlockedRecipe: SharedScreen(route = "shared/detail/blocked/{recipeId}") {
-        fun passRecipeId(recipeId: Int): String{
-            return "shared/detail/blocked/$recipeId"
+    object BlockedRecipe: SharedScreen(route = "shared/detail/blocked?recipeId={recipeId}&ownerId={ownerId}") {
+        fun passRecipeId(recipeId: Int, ownerId: Int): String{
+            return "shared/detail/blocked?recipeId=$recipeId&ownerId=$ownerId"
         }
     }
 

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/SharedNavGraph.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/SharedNavGraph.kt
@@ -1,6 +1,12 @@
 package com.zipdabang.zipdabang_android.core.navigation
 
 import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -10,7 +16,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
@@ -28,6 +37,7 @@ import com.zipdabang.zipdabang_android.common.TogglePreferenceException
 import com.zipdabang.zipdabang_android.core.data_store.proto.CurrentPlatform
 import com.zipdabang.zipdabang_android.module.comment.ui.RecipeCommentViewModel
 import com.zipdabang.zipdabang_android.module.comment.ui.ReportCommentInfoState
+import com.zipdabang.zipdabang_android.module.detail.recipe.ui.BlockNoticeViewModel
 import com.zipdabang.zipdabang_android.module.detail.recipe.ui.RecipeDetailLoading
 import com.zipdabang.zipdabang_android.module.detail.recipe.ui.RecipeDetailScreen
 import com.zipdabang.zipdabang_android.module.detail.recipe.ui.RecipeDetailViewModel
@@ -36,6 +46,7 @@ import com.zipdabang.zipdabang_android.module.search.ui.SearchScreen
 import com.zipdabang.zipdabang_android.ui.component.LoginRequestDialog
 import com.zipdabang.zipdabang_android.ui.component.Notice
 import com.zipdabang.zipdabang_android.ui.component.RecipeDeleteDialog
+import com.zipdabang.zipdabang_android.ui.theme.ZipdabangandroidTheme
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -55,19 +66,42 @@ fun NavGraphBuilder.SharedNavGraph(
         composable(
             route = SharedScreen.BlockedRecipe.route,
             arguments = listOf(
-                navArgument(name = "recipeId") { type = NavType.IntType }
+                navArgument(name = "recipeId") { type = NavType.IntType },
+                navArgument(name = "ownerId") { type = NavType.IntType }
             )
         ) { backStackEntry ->
             val recipeId = backStackEntry.arguments?.getInt("recipeId") ?: -1
+            val ownerId = backStackEntry.arguments?.getInt("ownerId") ?: -1
+
+            val viewModel = hiltViewModel<BlockNoticeViewModel>()
+            val cancelState = viewModel.cancelState.value
+
             Notice(
                 contentText = stringResource(id = R.string.notice_blocked_recipe),
                 buttonText = stringResource(id = R.string.button_cancel_block)
             ) {
+                viewModel.cancelUserBlock(ownerId)
+            }
+
+            if (cancelState.isLoading == true) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(48.dp),
+                        color = ZipdabangandroidTheme.Colors.Choco
+                    )
+                }
+            }
+
+            if (cancelState.isLoading == false && cancelState.data == true) {
                 navController.navigate(route = SharedScreen.DetailRecipe.passRecipeId(recipeId)) {
-                    launchSingleTop = true
                     popUpTo(route = SharedScreen.BlockedRecipe.route) {
                         inclusive = true
                     }
+                    launchSingleTop = true
                 }
             }
         }
@@ -84,7 +118,6 @@ fun NavGraphBuilder.SharedNavGraph(
                 val backStackEntries: List<NavBackStackEntry> = navController.currentBackStack.first()
                 for (entry in backStackEntries) {
                     val route = entry.destination.route
-                    // route를 사용하여 각 화면의 라우팅 정보 확인
                     Log.d("SharedNavGraph", "route : ${route}")
                 }
             }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/SharedNavGraph.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/SharedNavGraph.kt
@@ -34,6 +34,7 @@ import com.zipdabang.zipdabang_android.module.detail.recipe.ui.RecipeDetailViewM
 import com.zipdabang.zipdabang_android.module.search.ui.SearchCategoryScreen
 import com.zipdabang.zipdabang_android.module.search.ui.SearchScreen
 import com.zipdabang.zipdabang_android.ui.component.LoginRequestDialog
+import com.zipdabang.zipdabang_android.ui.component.Notice
 import com.zipdabang.zipdabang_android.ui.component.RecipeDeleteDialog
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
@@ -51,6 +52,26 @@ fun NavGraphBuilder.SharedNavGraph(
         startDestination = SharedScreen.DetailRecipe.route,
         route = SHARED_ROUTE
     ){
+        composable(
+            route = SharedScreen.BlockedRecipe.route,
+            arguments = listOf(
+                navArgument(name = "recipeId") { type = NavType.IntType }
+            )
+        ) { backStackEntry ->
+            val recipeId = backStackEntry.arguments?.getInt("recipeId") ?: -1
+            Notice(
+                contentText = stringResource(id = R.string.notice_blocked_recipe),
+                buttonText = stringResource(id = R.string.button_cancel_block)
+            ) {
+                navController.navigate(route = SharedScreen.DetailRecipe.passRecipeId(recipeId)) {
+                    launchSingleTop = true
+                    popUpTo(route = SharedScreen.BlockedRecipe.route) {
+                        inclusive = true
+                    }
+                }
+            }
+        }
+        
         composable(
             route = SharedScreen.DetailRecipe.route,
             arguments = listOf(

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/data/RecipeDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/data/RecipeDetailRepositoryImpl.kt
@@ -1,12 +1,15 @@
 package com.zipdabang.zipdabang_android.module.detail.recipe.data
 
 import com.zipdabang.zipdabang_android.common.ResponseBody
+import com.zipdabang.zipdabang_android.module.comment.data.remote.UserBlockDto
 import com.zipdabang.zipdabang_android.module.detail.recipe.domain.RecipeDetailRepository
+import com.zipdabang.zipdabang_android.module.my.data.remote.MyApi
 import com.zipdabang.zipdabang_android.module.recipes.data.RecipeApi
 import javax.inject.Inject
 
 class RecipeDetailRepositoryImpl @Inject constructor(
-    private val recipeApi: RecipeApi
+    private val recipeApi: RecipeApi,
+    private val myApi: MyApi
 ): RecipeDetailRepository {
     override suspend fun getRecipeDetail(accessToken: String, recipeId: Int): RecipeDetailDto {
         return recipeApi.getRecipeDetail(accessToken, recipeId)
@@ -28,5 +31,12 @@ class RecipeDetailRepositoryImpl @Inject constructor(
         accessToken: String, recipeId: Int
     ): ResponseBody<String?> {
         return recipeApi.deleteRecipe(accessToken, recipeId)
+    }
+
+    override suspend fun cancelUserBlock(
+        accessToken: String,
+        userId: Int
+    ): ResponseBody<UserBlockDto?> {
+        return myApi.cancelUserBlock(accessToken, userId)
     }
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/domain/RecipeDetailRepository.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/domain/RecipeDetailRepository.kt
@@ -1,6 +1,7 @@
 package com.zipdabang.zipdabang_android.module.detail.recipe.domain
 
 import com.zipdabang.zipdabang_android.common.ResponseBody
+import com.zipdabang.zipdabang_android.module.comment.data.remote.UserBlockDto
 import com.zipdabang.zipdabang_android.module.detail.recipe.data.RecipeDetailDto
 
 interface RecipeDetailRepository {
@@ -15,4 +16,8 @@ interface RecipeDetailRepository {
     suspend fun deleteRecipe(
         accessToken: String, recipeId: Int
     ): ResponseBody<String?>
+
+    suspend fun cancelUserBlock(
+        accessToken: String, userId: Int
+    ): ResponseBody<UserBlockDto?>
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/ui/BlockNoticeViewModel.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/ui/BlockNoticeViewModel.kt
@@ -1,0 +1,54 @@
+package com.zipdabang.zipdabang_android.module.detail.recipe.ui
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zipdabang.zipdabang_android.common.Resource
+import com.zipdabang.zipdabang_android.common.UiState
+import com.zipdabang.zipdabang_android.module.detail.recipe.use_case.CancelBlockUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@HiltViewModel
+class BlockNoticeViewModel @Inject constructor(
+    private val cancelBlockUseCase: CancelBlockUseCase
+): ViewModel() {
+
+    private val _cancelState = mutableStateOf<UiState<Boolean>>(UiState())
+    val cancelState: State<UiState<Boolean>> = _cancelState
+
+    fun cancelUserBlock(ownerId: Int) {
+        cancelBlockUseCase(ownerId).onEach { resource ->
+            when (resource) {
+                is Resource.Loading -> {
+                    _cancelState.value = UiState(
+                        isLoading = true
+                    )
+
+                }
+                is Resource.Success -> {
+                    _cancelState.value = UiState(
+                        isLoading = false,
+                        isSuccessful = true,
+                        data = true
+                    )
+
+                }
+                is Resource.Error -> {
+                    _cancelState.value = UiState(
+                        isLoading = false,
+                        isSuccessful = false,
+                        data = false
+                    )
+                }
+            }
+        }.launchIn(viewModelScope)
+    }
+}

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/use_case/CancelBlockUseCase.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/detail/recipe/use_case/CancelBlockUseCase.kt
@@ -1,0 +1,61 @@
+package com.zipdabang.zipdabang_android.module.detail.recipe.use_case
+
+import android.util.Log
+import androidx.datastore.core.DataStore
+import com.zipdabang.zipdabang_android.common.Resource
+import com.zipdabang.zipdabang_android.common.ResponseCode
+import com.zipdabang.zipdabang_android.common.getErrorCode
+import com.zipdabang.zipdabang_android.core.data_store.proto.Token
+import com.zipdabang.zipdabang_android.module.comment.domain.UserBlockResult
+import com.zipdabang.zipdabang_android.module.comment.use_case.BlockUserUseCase
+import com.zipdabang.zipdabang_android.module.comment.util.toUserBlockResult
+import com.zipdabang.zipdabang_android.module.detail.recipe.domain.RecipeDetailRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+
+class CancelBlockUseCase @Inject constructor(
+    private val tokenDataStore: DataStore<Token>,
+    private val repository: RecipeDetailRepository
+) {
+    operator fun invoke(userId: Int): Flow<Resource<UserBlockResult>> = flow {
+        try {
+            val accessToken = "Bearer ${tokenDataStore.data.first().accessToken}"
+            val result = repository.cancelUserBlock(accessToken, userId).toUserBlockResult()
+
+            when (result.code) {
+                ResponseCode.RESPONSE_DEFAULT.code -> {
+                    emit(Resource.Success(
+                        data = result,
+                        code = result.code,
+                        message = result.message
+                    ))
+                }
+                else -> {
+                    emit(Resource.Error(message = result.message))
+                }
+            }
+
+        } catch (e: HttpException) {
+            val errorBody = e.response()?.errorBody()
+            Log.e(BlockUserUseCase.TAG, errorBody?.string() ?: "error body is null")
+            val errorCode = errorBody?.getErrorCode()
+            errorCode?.let {
+                emit(Resource.Error(message = ResponseCode.getMessageByCode(errorCode)))
+                return@flow
+            }
+            emit(Resource.Error(message =  e.message ?: "unexpected http exception"))
+        } catch (e: IOException) {
+            emit(Resource.Error(message =  e.message ?: "unexpected io exception"))
+        } catch (e: Exception) {
+            if (e is CancellationException) {
+                throw e
+            }
+            emit(Resource.Error(message =  e.message ?: "unexpected exception"))
+        }
+    }
+}

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/my/data/remote/MyApi.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/my/data/remote/MyApi.kt
@@ -1,5 +1,7 @@
 package com.zipdabang.zipdabang_android.module.my.data.remote
 
+import com.zipdabang.zipdabang_android.common.ResponseBody
+import com.zipdabang.zipdabang_android.module.comment.data.remote.UserBlockDto
 import com.zipdabang.zipdabang_android.module.my.data.remote.followorcancel.FollowOrCancelDto
 import com.zipdabang.zipdabang_android.module.my.data.remote.friendlist.follow.FollowDto
 import com.zipdabang.zipdabang_android.module.my.data.remote.friendlist.follow.search.SearchFollowingDto
@@ -16,6 +18,7 @@ import com.zipdabang.zipdabang_android.module.my.data.remote.recipewrite.RecipeW
 import com.zipdabang.zipdabang_android.module.my.data.remote.recipewrite.RecipeWriteResponse
 import com.zipdabang.zipdabang_android.module.my.data.remote.recipewrite.RecipeWriteTempResponse
 import com.zipdabang.zipdabang_android.module.my.data.remote.signout.SignOutResponseDto
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Multipart
@@ -112,4 +115,10 @@ interface MyApi {
     suspend fun getRecipeWriteBeverages(
         @Header("Authorization") accessToken: String
     ) : RecipeWriteBeveragesResponse
+
+    @DELETE("members/unblock")
+    suspend fun cancelUserBlock(
+        @Header("Authorization") accessToken: String,
+        @Query("blocked") userId: Int
+    ): ResponseBody<UserBlockDto?>
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/data/hot/HotRecipeItem.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/data/hot/HotRecipeItem.kt
@@ -11,5 +11,8 @@ data class HotRecipeItem(
     val recipeId: Int,
     val recipeName: String,
     val comments: Int,
-    val thumbnailUrl: String?
+    val thumbnailUrl: String?,
+    // TODO API 확정 시 변수명 수정
+    val ownerId: Int,
+    val isBlocked: Boolean
 )

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/di/RecipeModule.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/di/RecipeModule.kt
@@ -9,6 +9,7 @@ import com.zipdabang.zipdabang_android.module.comment.data.RecipeCommentReposito
 import com.zipdabang.zipdabang_android.module.comment.domain.RecipeCommentRepository
 import com.zipdabang.zipdabang_android.module.detail.recipe.data.RecipeDetailRepositoryImpl
 import com.zipdabang.zipdabang_android.module.detail.recipe.domain.RecipeDetailRepository
+import com.zipdabang.zipdabang_android.module.my.data.remote.MyApi
 import com.zipdabang.zipdabang_android.module.recipes.data.RecipeApi
 import com.zipdabang.zipdabang_android.module.recipes.data.banner.RecipeBannerRepositoryImpl
 import com.zipdabang.zipdabang_android.module.recipes.data.category.RecipeCategoryRepositoryImpl
@@ -71,9 +72,10 @@ object RecipeModule {
     @Provides
     @Singleton
     fun provideRecipeDetailRepository(
-        recipeApi: RecipeApi
+        recipeApi: RecipeApi,
+        myApi: MyApi
     ): RecipeDetailRepository {
-        return RecipeDetailRepositoryImpl(recipeApi)
+        return RecipeDetailRepositoryImpl(recipeApi, myApi)
     }
 
     @Provides

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/RecipeScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/RecipeScreen.kt
@@ -41,6 +41,7 @@ fun RecipeScreen(
     onCategoryClick: (Int) -> Unit,
     onOwnerTypeClick: (String) -> Unit,
     onRecipeClick: (Int) -> Unit,
+    onBlockedRecipeClick: (Int, Int) -> Unit,
     onBannerClick: (String) -> Unit,
     onLoginRequest: () -> Unit,
     showSnackbar: (String) -> Unit,
@@ -134,6 +135,7 @@ fun RecipeScreen(
         TabItem.Coffee(
             hotItems = hotCoffeeRecipes,
             onRecipeClick = onRecipeClick,
+            onBlockedRecipeClick = onBlockedRecipeClick,
             onScrapClick = onScrapClick,
             onLikeClick = onLikeClick,
             likeState = likeState,
@@ -145,6 +147,7 @@ fun RecipeScreen(
         TabItem.CaffeineFree(
             hotItems = hotCaffeineFreeRecipes,
             onRecipeClick = onRecipeClick,
+            onBlockedRecipeClick = onBlockedRecipeClick,
             onScrapClick = onScrapClick,
             onLikeClick = onLikeClick,
             likeState = likeState,
@@ -156,6 +159,7 @@ fun RecipeScreen(
         TabItem.Tea(
             hotItems = hotTeaRecipes,
             onRecipeClick = onRecipeClick,
+            onBlockedRecipeClick = onBlockedRecipeClick,
             onScrapClick = onScrapClick,
             onLikeClick = onLikeClick,
             likeState = likeState,
@@ -167,6 +171,7 @@ fun RecipeScreen(
         TabItem.Ade(
             hotItems = hotAdeRecipes,
             onRecipeClick = onRecipeClick,
+            onBlockedRecipeClick = onBlockedRecipeClick,
             onScrapClick = onScrapClick,
             onLikeClick = onLikeClick,
             likeState = likeState,
@@ -178,6 +183,7 @@ fun RecipeScreen(
         TabItem.Smoothie(
             hotItems = hotSmoothieRecipes,
             onRecipeClick = onRecipeClick,
+            onBlockedRecipeClick = onBlockedRecipeClick,
             onScrapClick = onScrapClick,
             onLikeClick = onLikeClick,
             likeState = likeState,
@@ -189,6 +195,7 @@ fun RecipeScreen(
         TabItem.Fruit(
             hotItems = hotFruitRecipes,
             onRecipeClick = onRecipeClick,
+            onBlockedRecipeClick = onBlockedRecipeClick,
             onScrapClick = onScrapClick,
             onLikeClick = onLikeClick,
             likeState = likeState,
@@ -200,6 +207,7 @@ fun RecipeScreen(
         TabItem.WellBeing(
             hotItems = hotWellBeingRecipes,
             onRecipeClick = onRecipeClick,
+            onBlockedRecipeClick = onBlockedRecipeClick,
             onScrapClick = onScrapClick,
             onLikeClick = onLikeClick,
             likeState = likeState,
@@ -211,6 +219,7 @@ fun RecipeScreen(
         TabItem.All(
             hotItems = hotAllRecipes,
             onRecipeClick = onRecipeClick,
+            onBlockedRecipeClick = onBlockedRecipeClick,
             onScrapClick = onScrapClick,
             onLikeClick = onLikeClick,
             likeState = likeState,

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/hot/HotRecipeItem.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/hot/HotRecipeItem.kt
@@ -66,6 +66,7 @@ fun HotRecipeItem(
     index: Int,
     item: HotRecipeItem,
     onRecipeClick: (Int) -> Unit,
+    onBlockedRecipeClick: (Int, Int) -> Unit,
     onScrapClick: (Int) -> Unit,
     onLikeClick: (Int) -> Unit,
     likeState: PreferenceToggleState,
@@ -103,7 +104,11 @@ fun HotRecipeItem(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = rememberRipple()
             ) {
-                onRecipeClick(item.recipeId)
+                if (item.isBlocked) {
+                    onBlockedRecipeClick(item.recipeId, item.ownerId)
+                } else {
+                    onRecipeClick(item.recipeId)
+                }
             },
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
@@ -385,8 +390,9 @@ fun HotRecipeItemLoading() {
 fun HotRecipeItemPreview() {
     com.zipdabang.zipdabang_android.module.recipes.ui.hot.HotRecipeItem(
         index = 1,
-        item = HotRecipeItem(false, false, 1, "false", 1, "dsafs", 1, "https://github.com/zipdabang/android/assets/101035437/3711da12-6056-47df-b177-94ba33bfdecc"),
+        item = HotRecipeItem(false, false, 1, "false", 1, "dsafs", 1, "https://github.com/zipdabang/android/assets/101035437/3711da12-6056-47df-b177-94ba33bfdecc", 1, false),
         onRecipeClick = { int -> },
+        onBlockedRecipeClick = { int, a -> },
         onScrapClick = { int -> },
         onLikeClick = { int -> },
         likeState = PreferenceToggleState(),

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/hot/HotRecipeList.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/hot/HotRecipeList.kt
@@ -15,6 +15,7 @@ import com.zipdabang.zipdabang_android.module.recipes.ui.state.PreferenceToggleS
 fun HotRecipeList(
     hotItems: UiState<List<HotRecipeItem>>,
     onRecipeClick: (Int) -> Unit,
+    onBlockedRecipeClick: (Int, Int) -> Unit,
     onScrapClick: (Int) -> Unit,
     onLikeClick: (Int) -> Unit,
     likeState: PreferenceToggleState,
@@ -40,6 +41,7 @@ fun HotRecipeList(
                     index = index + 1,
                     item = recipesByOwnerType,
                     onRecipeClick = onRecipeClick,
+                    onBlockedRecipeClick = onBlockedRecipeClick,
                     onLikeClick = onLikeClick,
                     onScrapClick = onScrapClick,
                     likeState = likeState,

--- a/app/src/main/java/com/zipdabang/zipdabang_android/ui/component/Notice.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/ui/component/Notice.kt
@@ -1,0 +1,97 @@
+package com.zipdabang.zipdabang_android.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.zipdabang.zipdabang_android.ui.theme.ZipdabangandroidTheme
+
+@Composable
+fun Notice(
+    contentText: String,
+    buttonText: String,
+    onButtonClick: () -> Unit
+) {
+    // 어둡게 처리
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.7f)),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                textAlign = TextAlign.Center,
+                text = contentText,
+                color = Color.White,
+                style = ZipdabangandroidTheme
+                    .Typography.eighteen_700.copy(letterSpacing = 0.sp),
+                modifier = Modifier.padding(0.dp, 0.dp, 0.dp, 20.dp)
+            )
+            Button(
+                onClick = { onButtonClick() },
+                shape = ZipdabangandroidTheme.Shapes.medium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = ZipdabangandroidTheme.Colors.Strawberry,
+                ),
+                enabled = true
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = buttonText,
+                        textAlign = TextAlign.Center,
+                        style = ZipdabangandroidTheme
+                            .Typography.eighteen_700.copy(letterSpacing = 0.sp),
+                        color = Color.White,
+                        maxLines = 1,
+                        modifier = Modifier,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun NoticePreview() {
+    Notice(
+        contentText = "차단한 회원의 프로필입니다.\n" +
+            "보시려면 차단을 해제해주세요.",
+        buttonText = "차단 해제하기"
+    ) {
+
+    }
+}

--- a/app/src/main/java/com/zipdabang/zipdabang_android/ui/component/Notice.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/ui/component/Notice.kt
@@ -32,7 +32,6 @@ fun Notice(
     buttonText: String,
     onButtonClick: () -> Unit
 ) {
-    // 어둡게 처리
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,5 +221,7 @@
     <string name="dropdown_block_user">이용자 차단하기</string>
     <string name="recipe_owner_like_warning">본인 레시피에 좋아요를 누를 수 없습니다.</string>
 
-
+    <!--  Notice  -->
+    <string name="notice_blocked_recipe">차단한 회원의 프로필입니다.\n보시려면 차단을 해제해주세요.</string>
+    <string name="button_cancel_block">차단 해제하기</string>
 </resources>


### PR DESCRIPTION
### 🚩 관련 이슈
서버 측의 구현 이슈로 인하여 인기 레시피는 사용자 차단을 반영하지 못하는 상황으로 인하여 해당 기능 구현

### 📋 PR Checklist
- [ ] 차단된 사용자 레시피를 클릭했을 때, 알림창이 표출되는지
- [ ] 차단되지 않은 사용자 레시피 클릭 시 정상적으로 레시피 상세화면 이동
- [ ] 뒤로가기 클릭 시 이전 화면으로 이동하는지
- [ ] 차단 해제하기 버튼 클릭 시 차단 해제가 진행이 되었을 때 레시피 상세 정보를 조회할 수 있는가

### 📌 유의사항
없음