### PR TITLE
:bug: [FIX] 카테고리별 인기 레시피 제목 텍스트 너비 고정

### DIFF
--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/RecipeMenuScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/RecipeMenuScreen.kt
@@ -37,8 +37,6 @@ fun RecipeMenuScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
 
-
-
         LazyColumn(
             modifier = modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/hot/HotRecipeItem.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/recipes/ui/hot/HotRecipeItem.kt
@@ -114,7 +114,7 @@ fun HotRecipeItem(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Row(
-            modifier = Modifier.padding(start = 8.dp),
+            modifier = Modifier.padding(start = 8.dp).weight(85f),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
@@ -136,73 +136,71 @@ fun HotRecipeItem(
 
             Spacer(modifier = Modifier.width(12.dp))
 
+
             Column(
-                verticalArrangement = Arrangement.Center
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.Start,
             ) {
-                Column(
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.Start,
+
+                Text(
+                    text = item.nickname,
+                    overflow = TextOverflow.Ellipsis,
+                    style = ZipdabangandroidTheme.Typography.ten_300.copy(letterSpacing = 0.sp)
+                )
+
+                Text(
+                    text = item.recipeName,
+                    overflow = TextOverflow.Ellipsis,
+                    style = ZipdabangandroidTheme.Typography.fourteen_500.copy(letterSpacing = 0.sp),
+                    maxLines = 1
+                )
+
+                Row(
+                    modifier = Modifier,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-
-                    Text(
-                        text = item.nickname,
-                        overflow = TextOverflow.Ellipsis,
-                        style = ZipdabangandroidTheme.Typography.ten_300.copy(letterSpacing = 0.sp)
+                    Icon(
+                        painter = painterResource(id = favoriteCountIcon),
+                        contentDescription = "likes",
+                        tint = ZipdabangandroidTheme.Colors.Strawberry
                     )
 
+                    Spacer(modifier = Modifier.width(2.dp))
+
                     Text(
-                        text = item.recipeName,
-                        overflow = TextOverflow.Ellipsis,
-                        style = ZipdabangandroidTheme.Typography.fourteen_500.copy(letterSpacing = 0.sp)
+                        text = likes.toString(),
+                        style = TextStyle(
+                            color = ZipdabangandroidTheme.Colors.Typo,
+                            fontSize = 8.sp,
+                            fontWeight = FontWeight(300),
+                            fontFamily = FontFamily(Font(R.font.kopubworlddotum_light))
+                        )
                     )
 
-                    Row(
-                        modifier = Modifier,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            painter = painterResource(id = favoriteCountIcon),
-                            contentDescription = "likes",
-                            tint = ZipdabangandroidTheme.Colors.Strawberry
-                        )
+                    Spacer(modifier = Modifier.width(4.dp))
 
-                        Spacer(modifier = Modifier.width(2.dp))
-
-                        Text(
-                            text = likes.toString(),
-                            style = TextStyle(
-                                color = ZipdabangandroidTheme.Colors.Typo,
-                                fontSize = 8.sp,
-                                fontWeight = FontWeight(300),
-                                fontFamily = FontFamily(Font(R.font.kopubworlddotum_light))
-                            )
+                    Icon(
+                        painter = painterResource(id = commentCountIcon),
+                        contentDescription = "comments",
+                        tint = ZipdabangandroidTheme.Colors.Cream
+                    )
+                    Spacer(modifier = Modifier.width(2.dp))
+                    Text(
+                        // TODO comment 수 추가하기
+                        text = item.comments.toString(),
+                        style = TextStyle(
+                            color = ZipdabangandroidTheme.Colors.Typo,
+                            fontSize = 8.sp,
+                            fontWeight = FontWeight(300),
+                            fontFamily = FontFamily(Font(R.font.kopubworlddotum_light))
                         )
-
-                        Spacer(modifier = Modifier.width(4.dp))
-
-                        Icon(
-                            painter = painterResource(id = commentCountIcon),
-                            contentDescription = "comments",
-                            tint = ZipdabangandroidTheme.Colors.Cream
-                        )
-                        Spacer(modifier = Modifier.width(2.dp))
-                        Text(
-                            // TODO comment 수 추가하기
-                            text = item.comments.toString(),
-                            style = TextStyle(
-                                color = ZipdabangandroidTheme.Colors.Typo,
-                                fontSize = 8.sp,
-                                fontWeight = FontWeight(300),
-                                fontFamily = FontFamily(Font(R.font.kopubworlddotum_light))
-                            )
-                        )
-                    }
+                    )
                 }
             }
         }
 
         Row(
-            modifier = Modifier,
+            modifier = Modifier.weight(15f),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(modifier = Modifier.size(26.dp)) {
@@ -262,10 +260,7 @@ fun HotRecipeItem(
                     checkedColor = ZipdabangandroidTheme.Colors.Strawberry
                 )
             }
-
         }
-
-
     }
 }
 


### PR DESCRIPTION
### 🚩 관련 이슈
카테고리별 인기 레시피 아이템에서 제목의 길이가 긴 경우 아이콘이 사라지는 버그 해결
row의 weight 속성 활용, text의 maxLines을 1로 설정하여 ellipsis 처리

### 📋 PR Checklist
- [ ] 제목이 일정 영역을 넘어서면 ... 처리 되어야 함
- [ ] 이전과 동일하게 좋아요와 스크랩이 동작해야함

### 📌 유의사항
위와 같음