### PR TITLE
:bug::lipstick: [FIX] 로고 타이틀 텍스트 색상 매개변수 추가

### DIFF
--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/login/ui/LoginScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/login/ui/LoginScreen.kt
@@ -125,7 +125,7 @@ fun LoginScreen(
             val googleIcon = R.drawable.login_google
             val kakaoIcon = R.drawable.login_kakao
 
-            SplashTitle()
+            SplashTitle(color = ZipdabangandroidTheme.Colors.Choco)
 
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/splash/ui/SplashScreen.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/splash/ui/SplashScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -69,7 +70,7 @@ fun SplashScreen(
             modifier = Modifier
                 .padding(top = 100.dp, start = 20.dp)
         ) {
-            SplashTitle()
+            SplashTitle(color = Color.White)
         }
     }
 }

--- a/app/src/main/java/com/zipdabang/zipdabang_android/module/splash/ui/SplashTitle.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/module/splash/ui/SplashTitle.kt
@@ -26,7 +26,9 @@ import com.zipdabang.zipdabang_android.R
 import com.zipdabang.zipdabang_android.ui.theme.ZipdabangandroidTheme
 
 @Composable
-fun SplashTitle() {
+fun SplashTitle(
+    color: Color
+) {
 
     val splashLogo = R.drawable.zipdabanglogo_transparent_normal
 
@@ -53,7 +55,7 @@ fun SplashTitle() {
                 text = stringResource(R.string.zipdabang_title),
                 fontSize = 60.sp,
                 fontFamily = FontFamily(Font(R.font.cafe24ssurroundair)),
-                color = Color.White,
+                color = color,
                 textAlign = TextAlign.Center
             )
         }
@@ -62,7 +64,7 @@ fun SplashTitle() {
             fontSize = 18.sp,
             fontFamily = FontFamily(Font(R.font.cafe24ssurroundair)),
             fontWeight = FontWeight(300),
-            color = Color.White
+            color = color
         )
     }
 }
@@ -70,5 +72,5 @@ fun SplashTitle() {
 @Preview
 @Composable
 fun SplashTitlePreview() {
-    SplashTitle()
+    SplashTitle(color = Color.White)
 }


### PR DESCRIPTION
### 🚩 관련 이슈
온보딩에서 로고 텍스트 색이 흰색으로 나오는 것으로 인해 텍스트가 보이지 않는 이슈 해결

### 📋 PR Checklist
- [ ] Title Composable에 color 매개변수를 추가

### 📌 유의사항
없음