### PR TITLE
:bug: [FIX] 포그라운드에서 알림 클릭 시 해당 페이지로 이동하지 못하는 오류 해결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,6 @@
             android:name=".module.main.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:launchMode="singleTask"
             android:theme="@style/Theme.Zipdabangandroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
### 🚩 관련 이슈
포그라운드에서 알림 클릭 시 해당 페이지로 이동하지 못하는 오류

### 📋 PR Checklist
- [ ] AndroidManifest.xml 파일에서 activity의 launchMode를 staandard로 변경

### 📌 유의사항
다른 모든 기능들은 원래대로 동작해야 함
