### PR TITLE
:bug: [FIX] 레시피 리스트 화면 복귀 시 레시피 개수 반영 안되는 버그 해결

### DIFF
--- a/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/RecipeNavGraph.kt
+++ b/app/src/main/java/com/zipdabang/zipdabang_android/core/navigation/RecipeNavGraph.kt
@@ -135,23 +135,25 @@ fun NavGraphBuilder.RecipeNavGraph(
             }
 
 
-            LaunchedEffect(key1 = true) {
+/*            LaunchedEffect(key1 = true) {
                 viewModel.setSortBy("latest")
 
                 if (categoryState.categoryId == -1 && categoryState.ownerType != null) {
-                    viewModel.getOwnerItemCount(categoryState.ownerType)
+
                 } else {
-                    viewModel.getCategoryItemCount(categoryState.categoryId!!)
+
                 }
-            }
+            }*/
 
             LaunchedEffect(key1 = lifecycleEvent) {
                 if (lifecycleEvent == Lifecycle.Event.ON_RESUME) {
                     launch(Dispatchers.Main) {
                         if (categoryState.categoryId == -1 && categoryState.ownerType != null) {
                             viewModel.refreshOwnerItems()
+                            viewModel.getOwnerItemCount(categoryState.ownerType)
                         } else {
                             viewModel.refreshCategoryItems()
+                            viewModel.getCategoryItemCount(categoryState.categoryId!!)
                         }
                     }
                 }


### PR DESCRIPTION
### 🚩 관련 이슈
레시피 리스트 화면 복귀 시 레시피 개수 반영 안되는 버그 해결

### 📋 PR Checklist
- [x] 삭제나 차단 등의 이벤트로 레시피 리스트 화면 복귀 시 레시피 개수가 반영되어야 함

### 📌 유의사항
이전 동작은 그대로 동작